### PR TITLE
🔧⚙️🔩 [Breaking Change] (code + test) Move some command option into subcommand.

### DIFF
--- a/pymock_api/cmd.py
+++ b/pymock_api/cmd.py
@@ -94,7 +94,6 @@ class MockAPICommandParser:
         return self.parser
 
 
-SubCommand: str = "subcommand"
 SubParserAttr = namedtuple("SubParserAttr", ["title", "dest", "description", "help"])
 
 
@@ -107,8 +106,7 @@ class MetaCommandOption(type):
     def __new__(cls, name: str, bases: Tuple[type], attrs: dict):
         super_new = super().__new__
         parent = [b for b in bases if isinstance(b, MetaCommandOption)]
-        is_subcommand = re.search(r"'cli_option': '" + re.escape(SubCommand) + "'", str(attrs), re.IGNORECASE)
-        if not parent or is_subcommand:
+        if not parent:
             return super_new(cls, name, bases, attrs)
         parent_is_subcmd = list(filter(lambda b: re.search(r"SubCommand\w{1,10}Option", b.__name__), bases))
         if parent_is_subcmd:
@@ -186,7 +184,18 @@ class CommandOption:
         return copy.copy(self)
 
 
+class SubCommandRunOption(CommandOption):
+
+    sub_cmd: SubParserAttr = SubParserAttr(
+        title="Running an application",
+        dest="run",
+        description="",
+        help="Set up APIs and start to run an application.",
+    )
+
+
 CommandOption = MetaCommandOption("CommandOption", (CommandOption,), {})
+SubCommandRunOption = MetaCommandOption("SubCommandRunOption", (SubCommandRunOption,), {})
 
 
 class Version(CommandOption):
@@ -208,17 +217,6 @@ class Version(CommandOption):
             "version": self._version_output,
         }
         parser.add_argument(*self.cli_option_name, **cmd_option_args)
-
-
-class SubCommandRunOption(CommandOption):
-
-    sub_cmd: SubParserAttr = SubParserAttr(
-        title="Running an application",
-        dest="run",
-        description="",
-        help="Set up APIs and start to run an application.",
-    )
-    cli_option: str = SubCommand
 
 
 class WebAppType(SubCommandRunOption):

--- a/pymock_api/runner.py
+++ b/pymock_api/runner.py
@@ -17,7 +17,8 @@ except (ImportError, ModuleNotFoundError):
 
 class CommandRunner:
     def __init__(self):
-        self.cmd_parser = pymock_api.cmd.MockAPICommandParser().parse()
+        self.mock_api_parser = pymock_api.cmd.MockAPICommandParser()
+        self.cmd_parser = self.mock_api_parser.parse()
         self.sgi_cmd: WSGICmd = None
 
     def run(self, args: ParserArguments) -> None:
@@ -26,7 +27,7 @@ class CommandRunner:
 
     def parse(self, cmd_args: List[str] = None) -> ParserArguments:
         args = self._parse_cmd_arguments(cmd_args)
-        parser_options = deserialize_parser_args(args)
+        parser_options = deserialize_parser_args(args, subcmd=self.mock_api_parser.subcommand)
         self._process_option(parser_options)
         return parser_options
 

--- a/pymock_api/runner.py
+++ b/pymock_api/runner.py
@@ -17,7 +17,7 @@ except (ImportError, ModuleNotFoundError):
 
 class CommandRunner:
     def __init__(self):
-        self.parser = pymock_api.cmd.MockAPICommandParser()
+        self.cmd_parser = pymock_api.cmd.MockAPICommandParser().parse()
         self.sgi_cmd: WSGICmd = None
 
     def run(self, args: ParserArguments) -> None:
@@ -25,15 +25,13 @@ class CommandRunner:
         command.run()
 
     def parse(self, cmd_args: List[str] = None) -> ParserArguments:
-        args = self._load_parser(cmd_args)
+        args = self._parse_cmd_arguments(cmd_args)
         parser_options = deserialize_parser_args(args)
         self._process_option(parser_options)
         return parser_options
 
-    def _load_parser(self, cmd_args=None) -> Namespace:
-        parser = self.parser.parse()
-        args = parser.parse_args(cmd_args)
-        return args
+    def _parse_cmd_arguments(self, cmd_args: List[str]) -> Namespace:
+        return self.cmd_parser.parse_args(cmd_args)
 
     def _process_option(self, parser_options: ParserArguments) -> None:
         # Note: It's possible that it should separate the functions to be multiple objects to implement and manage the

--- a/pymock_api/server/sgi/__init__.py
+++ b/pymock_api/server/sgi/__init__.py
@@ -4,13 +4,14 @@ The factory to generate SGI application instance to run Python web framework.
 """
 
 from argparse import Namespace
+from typing import Optional
 
 from ._model import Command, CommandOptions, Deserialize, ParserArguments
 from .cmd import WSGICmd
 from .cmdoption import WSGICmdOption
 
 
-def deserialize_parser_args(args: Namespace) -> ParserArguments:
+def deserialize_parser_args(args: Namespace, subcmd: Optional[str] = None) -> ParserArguments:
     """Deserialize the object *argparse.Namespace* to *ParserArguments*.
 
     Args:
@@ -20,4 +21,4 @@ def deserialize_parser_args(args: Namespace) -> ParserArguments:
         A *ParserArguments* type object.
 
     """
-    return Deserialize.parser_arguments(args)
+    return Deserialize.parser_arguments(args, subcmd)

--- a/pymock_api/server/sgi/_model.py
+++ b/pymock_api/server/sgi/_model.py
@@ -2,13 +2,14 @@ import logging
 import subprocess
 from argparse import Namespace
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
 
 @dataclass
 class ParserArguments:
     """*The data object for the arguments from parsing the command line of PyMock-API program*"""
 
+    subparser_name: str = None
     config: str = None
     app_type: str = None
     bind: str = None
@@ -67,7 +68,13 @@ class Deserialize:
     """*Deserialize the object *argparse.Namespace* to *ParserArguments*"""
 
     @classmethod
-    def parser_arguments(cls, args: Namespace) -> ParserArguments:
+    def parser_arguments(cls, args: Namespace, subcmd: Optional[str] = None) -> ParserArguments:
+        subparser_name = getattr(args, subcmd) if subcmd else None
         return ParserArguments(
-            config=args.config, app_type=args.app_type, bind=args.bind, workers=args.workers, log_level=args.log_level
+            subparser_name=subparser_name,
+            config=args.config,
+            app_type=args.app_type,
+            bind=args.bind,
+            workers=args.workers,
+            log_level=args.log_level,
         )

--- a/test/_values.py
+++ b/test/_values.py
@@ -78,5 +78,6 @@ _Workers_Amount: _Cmd_Option = _Cmd_Option(option_name="--workers", value=3)
 _Log_Level: _Cmd_Option = _Cmd_Option(option_name="--log-level", value="info")
 
 # Test command line options
+_Test_SubCommand: str = "run"
 _Test_Config: str = "test-api.yaml"
 _Test_App_Type: str = "flask"

--- a/test/integration_test/run_cmd.py
+++ b/test/integration_test/run_cmd.py
@@ -75,7 +75,7 @@ class StreamingOutputCommandFunctionTestSpec(CommandFunctionTestSpec, ABC):
 class TestRunApplicationToMockAPIsWithFlaskAndGunicorn(StreamingOutputCommandFunctionTestSpec):
     @property
     def options(self) -> List[str]:
-        return ["--app-type", "flask", "--bind", _Bind_Host_And_Port.value, "--config", MockAPI_Config_Path]
+        return ["run", "--app-type", "flask", "--bind", _Bind_Host_And_Port.value, "--config", MockAPI_Config_Path]
 
     @classmethod
     def _kill_all_server_workers(cls) -> None:

--- a/test/integration_test/runner.py
+++ b/test/integration_test/runner.py
@@ -22,9 +22,11 @@ class Capturing(list):
 
 
 class CommandFunctionTestSpec(metaclass=ABCMeta):
-    @pytest.fixture(scope="function")
+    _Command_Runner: CommandRunner = CommandRunner()
+
+    @pytest.fixture(scope="module", autouse=True)
     def runner(self) -> CommandRunner:
-        return CommandRunner()
+        return self._Command_Runner
 
     @property
     @abstractmethod
@@ -55,12 +57,9 @@ class TestHelp(CommandFunctionTestSpec):
         return ["--help"]
 
     def verify_running_output(self, cmd_running_result) -> None:
-        self._should_contains_chars_in_result(cmd_running_result, "mock-api [OPTIONS]")
+        self._should_contains_chars_in_result(cmd_running_result, "mock-api [SUBCOMMAND] [OPTIONS]")
         self._should_contains_chars_in_result(cmd_running_result, "-h, --help")
-        self._should_contains_chars_in_result(cmd_running_result, "-c CONFIG, --config CONFIG")
-        self._should_contains_chars_in_result(cmd_running_result, "-b BIND, --bind BIND")
-        self._should_contains_chars_in_result(cmd_running_result, "-w WORKERS, --workers WORKERS")
-        self._should_contains_chars_in_result(cmd_running_result, "--log-level LOG_LEVEL")
+        self._should_contains_chars_in_result(cmd_running_result, "-v, --version")
 
 
 class TestVersion(CommandFunctionTestSpec):

--- a/test/integration_test/runner.py
+++ b/test/integration_test/runner.py
@@ -62,6 +62,20 @@ class TestHelp(CommandFunctionTestSpec):
         self._should_contains_chars_in_result(cmd_running_result, "-v, --version")
 
 
+class TestSubCommandRunHelp(CommandFunctionTestSpec):
+    @property
+    def options(self) -> List[str]:
+        return ["run", "--help"]
+
+    def verify_running_output(self, cmd_running_result) -> None:
+        self._should_contains_chars_in_result(cmd_running_result, "mock-api [SUBCOMMAND] [OPTIONS]")
+        self._should_contains_chars_in_result(cmd_running_result, "-h, --help")
+        self._should_contains_chars_in_result(cmd_running_result, "-c CONFIG, --config CONFIG")
+        self._should_contains_chars_in_result(cmd_running_result, "-b BIND, --bind BIND")
+        self._should_contains_chars_in_result(cmd_running_result, "-w WORKERS, --workers WORKERS")
+        self._should_contains_chars_in_result(cmd_running_result, "--log-level LOG_LEVEL")
+
+
 class TestVersion(CommandFunctionTestSpec):
     @property
     def options(self) -> List[str]:

--- a/test/integration_test/runner.py
+++ b/test/integration_test/runner.py
@@ -33,7 +33,7 @@ class CommandFunctionTestSpec(metaclass=ABCMeta):
     def options(self) -> List[str]:
         pass
 
-    def test_command(self, capsys, runner: CommandRunner):
+    def test_command(self, runner: CommandRunner):
         with Capturing() as output:
             with pytest.raises(SystemExit):
                 runner.parse(cmd_args=self.options)

--- a/test/unit_test/server/sgi/init.py
+++ b/test/unit_test/server/sgi/init.py
@@ -8,18 +8,21 @@ from ...._values import (
     _Log_Level,
     _Test_App_Type,
     _Test_Config,
+    _Test_SubCommand,
     _Workers_Amount,
 )
 
 
 @patch.object(Deserialize, "parser_arguments")
 def test_deserialize_parser_args(mock_parser_arguments: Mock):
-    namespace = Namespace(
-        config=_Test_Config,
-        app_type=_Test_App_Type,
-        bind=_Bind_Host_And_Port.value,
-        workers=_Workers_Amount.value,
-        log_level=_Log_Level.value,
-    )
-    deserialize_parser_args(namespace)
-    mock_parser_arguments.assert_called_once_with(namespace)
+    namespace_args = {
+        _Test_SubCommand: _Test_SubCommand,
+        "config": _Test_Config,
+        "app_type": _Test_App_Type,
+        "bind": _Bind_Host_And_Port.value,
+        "workers": _Workers_Amount.value,
+        "log_level": _Log_Level.value,
+    }
+    namespace = Namespace(**namespace_args)
+    deserialize_parser_args(namespace, subcmd=_Test_SubCommand)
+    mock_parser_arguments.assert_called_once_with(namespace, _Test_SubCommand)

--- a/test/unit_test/server/sgi/model.py
+++ b/test/unit_test/server/sgi/model.py
@@ -18,6 +18,7 @@ from ...._values import (
     _Test_App_Type,
     _Test_Config,
     _Test_Entry_Point,
+    _Test_SubCommand,
     _Workers_Amount,
 )
 
@@ -86,15 +87,18 @@ class TestDeserialize:
         return Deserialize
 
     def test_parser_arguments(self, deserialize: Type[Deserialize]):
-        namespace = Namespace(
-            config=_Test_Config,
-            app_type=_Test_App_Type,
-            bind=_Bind_Host_And_Port.value,
-            workers=_Workers_Amount.value,
-            log_level=_Log_Level.value,
-        )
-        arguments = deserialize.parser_arguments(namespace)
+        namespace_args = {
+            _Test_SubCommand: _Test_SubCommand,
+            "config": _Test_Config,
+            "app_type": _Test_App_Type,
+            "bind": _Bind_Host_And_Port.value,
+            "workers": _Workers_Amount.value,
+            "log_level": _Log_Level.value,
+        }
+        namespace = Namespace(**namespace_args)
+        arguments = deserialize.parser_arguments(namespace, subcmd=_Test_SubCommand)
         assert isinstance(arguments, ParserArguments)
+        assert arguments.subparser_name == _Test_SubCommand
         assert arguments.config == _Test_Config
         assert arguments.app_type == _Test_App_Type
         assert arguments.bind == _Bind_Host_And_Port.value


### PR DESCRIPTION
### _Target_

* Move some command option into subcommand.
    For example, the old usage commend line like below:
    ```shell
    >>> mock-api --app-type flask --bind 127.0.0.1:9672
    ```
    
    The new usage command line would as following:
    ```shell
    >>> mock-api run --app-type flask --bind 127.0.0.1:9672
    ```


### _Modify Code Scope_

* Source Code
    * module _cmd_
    * module _runner_
    * module _server.sgi.\_\_init\_\__
    * module _server.sgi.\_model_

* Testing Code
    * Common Module
        * test module _\_values_

    * Unit Test
        * test module _server.sgi.init__
        * test module _server.sgi.model__

    * Integration Test
        * test module _runner__
        * test module _run_cmd__


### _Effecting Scope_

* Modify the usage of command line to let it to be more user-friendly and easier to extend other site features in the future.


### _Description_

* Add one more class about all sub-class of it is one specific subcommand _run_'s option and instantiate it by meta class.
* Modify all option classes to extend of the new object which relative about running application.
* Add processing of new argument about subcommand. 
* Adjust the test implementations.
