### PR TITLE
🔧⚙️🔩 [Breaking Change] (config) Fix the breaking CI process about upload test coverage report to CodeCov because of deprecated Python package *codecov*.

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,8 +15,6 @@ on:
       - ".gitignore"
       - "LICENSE"
       - "README.md"
-      - "poetry.lock"
-      - "pyproject.toml"
 
   pull_request:
     branches:
@@ -32,8 +30,6 @@ on:
       - ".gitignore"
       - "LICENSE"
       - "README.md"
-      - "poetry.lock"
-      - "pyproject.toml"
 
 jobs:
   prep-testbed_unit-test:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -79,7 +79,7 @@ jobs:
   codecov_finish:
 #    name: Organize and generate the testing report and upload it to Codecov
     needs: all-test_codecov
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/upload_test_cov_report.yaml@v4
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/upload_test_cov_report.yaml@develop
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
     with:

--- a/poetry.lock
+++ b/poetry.lock
@@ -72,11 +72,7 @@ version = "2.1.12"
 description = "Hosted coverage reports for GitHub, Bitbucket and Gitlab"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[package.dependencies]
-coverage = "*"
-requests = ">=2.7.9"
+python-versions = "*"
 
 [[package]]
 name = "colorama"
@@ -940,10 +936,7 @@ click = [
     {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
     {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
 ]
-codecov = [
-    {file = "codecov-2.1.12-py2.py3-none-any.whl", hash = "sha256:585dc217dc3d8185198ceb402f85d5cb5dbfa0c5f350a5abcdf9e347776a5b47"},
-    {file = "codecov-2.1.12.tar.gz", hash = "sha256:a0da46bb5025426da895af90938def8ee12d37fcbcbbbc15b6dc64cf7ebc51c1"},
-]
+codecov = []
 colorama = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -67,14 +67,6 @@ python-versions = ">=3.7"
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
-name = "codecov"
-version = "2.1.12"
-description = "Hosted coverage reports for GitHub, Bitbucket and Gitlab"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -435,7 +427,7 @@ python-versions = ">= 3.7"
 
 [[package]]
 name = "packaging"
-version = "23.0"
+version = "23.1"
 description = "Core utilities for Python packages"
 category = "dev"
 optional = false
@@ -836,7 +828,7 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "7e90e6ef1664b558fe3e89eeb19fa5340323a0524a4502f11379135b7e8deb59"
+content-hash = "fcd9a1b63cb8d638609b270273a249230903d19f96e9b1eeb0f6e21a1d62af3d"
 
 [metadata.files]
 anyio = [
@@ -936,7 +928,6 @@ click = [
     {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
     {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
 ]
-codecov = []
 colorama = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -1276,8 +1267,8 @@ orjson = [
     {file = "orjson-3.8.10.tar.gz", hash = "sha256:dcf6adb4471b69875034afab51a14b64f1026bc968175a2bb02c5f6b358bd413"},
 ]
 packaging = [
-    {file = "packaging-23.0-py3-none-any.whl", hash = "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2"},
-    {file = "packaging-23.0.tar.gz", hash = "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"},
+    {file = "packaging-23.1-py3-none-any.whl", hash = "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61"},
+    {file = "packaging-23.1.tar.gz", hash = "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"},
 ]
 platformdirs = [
     {file = "platformdirs-3.2.0-py3-none-any.whl", hash = "sha256:ebe11c0d7a805086e99506aa331612429a72ca7cd52a1f0d277dc4adc20cb10e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ pytest-cov = "^3.0.0"
 pytest-html = "^3.1.1"
 pytest-rerunfailures = "^10.2"
 coverage = "^6.2"
-codecov = "^2.1.12"
 coveralls = "^3.3.1"
 # Dependency for CI
 pre-commit = "^3.0.4"


### PR DESCRIPTION
### _Target_

* Fix the breaking CI process about upload test coverage report to **CodeCov** because of deprecated Python package **_codecov_**.


### _Modify Code Scope_

* Configuration
    * Standard Python project configuration _pyproject.toml_
    * **Poetry** _poetry.lock_
    * **GitHub Action** workflow _.github/workflows/ci-cd.yml_


### _Effecting Scope_

* Nothing, this PR like refactoring of CI process. It won't effect anything of CI process, but it changes the working way to upload test coverage report to **CodeCov** service.


### _Description_

* Remove deprecated Python package **_codecov_**.
    * Relative issue: https://github.com/home-assistant/core/issues/91283
    * Refer: https://docs.codecov.com/docs/deprecated-uploader-migration-guide#python-uploader
* Update the Poetry lock file because previous one change.
* Modify the CI setting to use _develop_ version of template reusable workflow.
