### PR TITLE
🎉🎊🍾 [New Feature] (code + test) Support to automatically scan which Python web library could be used to initial and set up server gateway.

### DIFF
--- a/pymock_api/_utils/importing.py
+++ b/pymock_api/_utils/importing.py
@@ -1,6 +1,7 @@
 """*Handle importing*"""
 
-from typing import Callable
+import re
+from typing import Callable, Optional
 
 
 class import_web_lib:
@@ -19,6 +20,17 @@ class import_web_lib:
         import fastapi
 
         return fastapi
+
+    @staticmethod
+    def auto_ready() -> Optional[str]:
+        self = import_web_lib
+        all_ready_funs = list(filter(lambda e: re.search(r"\w{1,16}_ready", e), dir(self)))
+        ready_funs = list(filter(lambda e: not re.search(r"^(_|auto)\w{1,16}", e), all_ready_funs))
+        could_import_lib = list(map(lambda e: getattr(self, e)(), ready_funs))
+        try:
+            return ready_funs[could_import_lib.index(True)].replace("_ready", "")
+        except ValueError:
+            return None
 
     @staticmethod
     def flask_ready() -> bool:

--- a/pymock_api/_utils/importing.py
+++ b/pymock_api/_utils/importing.py
@@ -20,6 +20,23 @@ class import_web_lib:
 
         return fastapi
 
+    @staticmethod
+    def flask_ready() -> bool:
+        return import_web_lib._chk_lib_ready(import_web_lib.flask)
+
+    @staticmethod
+    def fastapi_ready() -> bool:
+        return import_web_lib._chk_lib_ready(import_web_lib.fastapi)
+
+    @staticmethod
+    def _chk_lib_ready(lib_import: Callable) -> bool:
+        try:
+            lib_import()
+        except ImportError:
+            return False
+        else:
+            return True
+
 
 def ensure_importing(import_callback: Callable, import_err_callback: Callable = None) -> Callable:
     """Load application if importing works finely without any issue. Or it will do nothing.

--- a/pymock_api/cmd.py
+++ b/pymock_api/cmd.py
@@ -264,11 +264,20 @@ class Version(CommandOption):
 
 
 class WebAppType(SubCommandRunOption):
+    """
+    Which Python web framework it should use to set up web server for mocking APIs.
+
+    Option values:
+        * *auto*: it would automatically scan which Python web library it could use to initial and set up server gateway in current runtime environment.
+        * *flask*: Use Python web framework Flask (https://palletsprojects.com/p/flask/) to set up web application.
+        * *fastapi*: Use Python web framework FastAPI (https://fastapi.tiangolo.com/) to set up web application.
+    """
+
     cli_option: str = "--app-type"
     name: str = "app_type"
     help_description: str = "Which Python web framework it should use to set up web server for mocking APIs."
-    default_value: str = "flask"
-    _options: List[str] = ["flask"]
+    default_value: str = "auto"
+    _options: List[str] = ["auto", "flask", "fastapi"]
 
 
 class Config(SubCommandRunOption):

--- a/pymock_api/cmd_ps.py
+++ b/pymock_api/cmd_ps.py
@@ -4,7 +4,7 @@ import re
 from argparse import ArgumentParser, Namespace
 from typing import List, Optional, Tuple, Type
 
-from ._utils import YAML
+from ._utils import YAML, import_web_lib
 from .cmd import MockAPICommandParser, SubCommand
 from .model import (
     ParserArguments,
@@ -138,12 +138,19 @@ class SubCmdRun(BaseCommandProcessor):
         os.environ["MockAPI_Config"] = parser_options.config
 
         # Handle *app-type*
-        if re.search(r"flask", parser_options.app_type, re.IGNORECASE):
+        self._initial_server_gateway(lib=parser_options.app_type)
+
+    def _initial_server_gateway(self, lib: str) -> None:
+        if re.search(r"auto", lib, re.IGNORECASE):
             self._server_gateway = setup_wsgi()
-        elif re.search(r"fastapi", parser_options.app_type, re.IGNORECASE):
+        elif re.search(r"flask", lib, re.IGNORECASE):
+            self._server_gateway = setup_wsgi()
+        elif re.search(r"fastapi", lib, re.IGNORECASE):
             self._server_gateway = setup_asgi()
         else:
-            raise ValueError("Invalid value at argument *app-type*. It only supports 'flask' or 'fastapi' currently.")
+            raise ValueError(
+                "Invalid value at argument *app-type*. It only supports 'auto', 'flask' or 'fastapi' currently."
+            )
 
 
 class SubCmdConfig(BaseCommandProcessor):

--- a/pymock_api/cmd_ps.py
+++ b/pymock_api/cmd_ps.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Tuple, Type
 
 from ._utils import YAML, import_web_lib
 from .cmd import MockAPICommandParser, SubCommand
-from .exceptions import NoValidWebLibrary
+from .exceptions import InvalidAppType, NoValidWebLibrary
 from .model import (
     ParserArguments,
     SubcmdConfigArguments,
@@ -152,9 +152,7 @@ class SubCmdRun(BaseCommandProcessor):
         elif re.search(r"fastapi", lib, re.IGNORECASE):
             self._server_gateway = setup_asgi()
         else:
-            raise ValueError(
-                "Invalid value at argument *app-type*. It only supports 'auto', 'flask' or 'fastapi' currently."
-            )
+            raise InvalidAppType
 
 
 class SubCmdConfig(BaseCommandProcessor):

--- a/pymock_api/cmd_ps.py
+++ b/pymock_api/cmd_ps.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Tuple, Type
 
 from ._utils import YAML, import_web_lib
 from .cmd import MockAPICommandParser, SubCommand
+from .exceptions import NoValidWebLibrary
 from .model import (
     ParserArguments,
     SubcmdConfigArguments,
@@ -142,7 +143,10 @@ class SubCmdRun(BaseCommandProcessor):
 
     def _initial_server_gateway(self, lib: str) -> None:
         if re.search(r"auto", lib, re.IGNORECASE):
-            self._server_gateway = setup_wsgi()
+            web_lib = import_web_lib.auto_ready()
+            if not web_lib:
+                raise NoValidWebLibrary
+            self._initial_server_gateway(lib=web_lib)
         elif re.search(r"flask", lib, re.IGNORECASE):
             self._server_gateway = setup_wsgi()
         elif re.search(r"fastapi", lib, re.IGNORECASE):

--- a/pymock_api/exceptions.py
+++ b/pymock_api/exceptions.py
@@ -16,3 +16,11 @@ class FunctionNotFoundError(RuntimeError):
 
     def __str__(self):
         return f"Cannot find the function {self._function} in current module."
+
+
+class NoValidWebLibrary(RuntimeError):
+    def __str__(self):
+        return (
+            "Cannot initial and set up server gateway because current runtime environment doesn't have valid web "
+            "library."
+        )

--- a/pymock_api/exceptions.py
+++ b/pymock_api/exceptions.py
@@ -24,3 +24,8 @@ class NoValidWebLibrary(RuntimeError):
             "Cannot initial and set up server gateway because current runtime environment doesn't have valid web "
             "library."
         )
+
+
+class InvalidAppType(ValueError):
+    def __str__(self):
+        return "Invalid value at argument *app-type*. It only supports 'auto', 'flask' or 'fastapi' currently."

--- a/test/_values.py
+++ b/test/_values.py
@@ -99,6 +99,7 @@ _Log_Level: _Cmd_Option = _Cmd_Option(option_name="--log-level", value="info")
 # Test command line options
 _Test_SubCommand_Run: str = "run"
 _Test_Config: str = "test-api.yaml"
+_Test_Auto_Type: str = "auto"
 _Test_App_Type: str = "flask"
 _Test_FastAPI_App_Type: str = "fastapi"
 

--- a/test/integration_test/run_cmd.py
+++ b/test/integration_test/run_cmd.py
@@ -209,3 +209,21 @@ class TestRunMockApplicationWithFastAPI(RunMockApplicationTestSpec):
             cmd_running_result, f"Uvicorn running on http://{_Bind_Host_And_Port.value}"
         )
         super()._verify_running_output(cmd_running_result)
+
+
+class TestRunMockApplicationWithAuto(RunMockApplicationTestSpec):
+    @property
+    def options(self) -> str:
+        return f"run --app-type auto --bind {_Bind_Host_And_Port.value} --config {MockAPI_Config_Path}"
+
+    def _do_finally(self) -> None:
+        subprocess.run("pkill -f uvicorn", shell=True)
+
+    def _verify_running_output(self, cmd_running_result: str) -> None:
+        self._should_contains_chars_in_result(cmd_running_result, "Started server process")
+        self._should_contains_chars_in_result(cmd_running_result, "Waiting for application startup")
+        self._should_contains_chars_in_result(cmd_running_result, "Application startup complete")
+        self._should_contains_chars_in_result(
+            cmd_running_result, f"Uvicorn running on http://{_Bind_Host_And_Port.value}"
+        )
+        super()._verify_running_output(cmd_running_result)

--- a/test/unit_test/_utils/importing.py
+++ b/test/unit_test/_utils/importing.py
@@ -1,6 +1,6 @@
 import re
-from typing import Callable, Type
-from unittest.mock import Mock, _patch, patch
+from typing import Any, Callable, Type
+from unittest.mock import MagicMock, Mock, _patch, patch
 
 import fastapi
 import flask
@@ -23,6 +23,32 @@ class TestImportWebLib:
 
     def test_import_web_lib_fastapi(self, import_web_lib: Type[import_web_lib]):
         assert import_web_lib.fastapi() == fastapi
+
+    @pytest.mark.parametrize(
+        ("site_effect", "lib_ready"),
+        [(None, True), (ImportError("PyTest ImportError"), False)],
+    )
+    def test_flask_ready(self, site_effect: Any, lib_ready: bool, import_web_lib: Type[import_web_lib]):
+        # Mock function
+        og_flask = import_web_lib.flask
+        import_web_lib.flask = MagicMock(site_effect=site_effect)
+        # Run target function under test
+        assert import_web_lib.flask_ready()
+        # Annotate the function back to correct implementation
+        import_web_lib.flask = og_flask
+
+    @pytest.mark.parametrize(
+        ("site_effect", "lib_ready"),
+        [(None, True), (ImportError("PyTest ImportError"), False)],
+    )
+    def test_fastapi_ready(self, site_effect: Any, lib_ready: bool, import_web_lib: Type[import_web_lib]):
+        # Mock function
+        og_fastapi = import_web_lib.fastapi
+        import_web_lib.fastapi = MagicMock(site_effect=site_effect)
+        # Run target function under test
+        assert import_web_lib.fastapi_ready()
+        # Annotate the function back to correct implementation
+        import_web_lib.fastapi = og_fastapi
 
 
 class TestEnsureImporting:

--- a/test/unit_test/_utils/importing.py
+++ b/test/unit_test/_utils/importing.py
@@ -66,9 +66,16 @@ class TestImportWebLib:
         ready_lib: Optional[str],
         import_web_lib: Type[import_web_lib],
     ):
+        # Mock function
+        og_flask_ready = import_web_lib.flask_ready
+        og_fastapi_ready = import_web_lib.fastapi_ready
         import_web_lib.flask_ready = MagicMock(return_value=flask_ready_return)
         import_web_lib.fastapi_ready = MagicMock(return_value=fastapi_ready_return)
+        # Run target function under test
         assert import_web_lib.auto_ready() == ready_lib
+        # Annotate the function back to correct implementation
+        import_web_lib.flask_ready = og_flask_ready
+        import_web_lib.fastapi_ready = og_fastapi_ready
 
 
 class TestEnsureImporting:

--- a/test/unit_test/_utils/importing.py
+++ b/test/unit_test/_utils/importing.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Callable, Type
+from typing import Any, Callable, Optional, Type
 from unittest.mock import MagicMock, Mock, _patch, patch
 
 import fastapi
@@ -49,6 +49,26 @@ class TestImportWebLib:
         assert import_web_lib.fastapi_ready()
         # Annotate the function back to correct implementation
         import_web_lib.fastapi = og_fastapi
+
+    @pytest.mark.parametrize(
+        ("flask_ready_return", "fastapi_ready_return", "ready_lib"),
+        [
+            (True, True, "fastapi"),
+            (True, False, "flask"),
+            (False, True, "fastapi"),
+            (False, False, None),
+        ],
+    )
+    def test_auto_ready(
+        self,
+        flask_ready_return: bool,
+        fastapi_ready_return: bool,
+        ready_lib: Optional[str],
+        import_web_lib: Type[import_web_lib],
+    ):
+        import_web_lib.flask_ready = MagicMock(return_value=flask_ready_return)
+        import_web_lib.fastapi_ready = MagicMock(return_value=fastapi_ready_return)
+        assert import_web_lib.auto_ready() == ready_lib
 
 
 class TestEnsureImporting:


### PR DESCRIPTION
### _Target_

* Support to automatically scan which Python web library could be used to initial and set up server gateway.
* Usage example:
    * AS-IT
    ```shell
    >>> mock-api --app-type 'flask'
    ```

    * TO-BE
    ```shell
    >>> mock-api
    ```

### _Modify Code Scope_

* Source Code
    * module: _\_utils.importing_
    * module: _cmd_
    * module: _cmd_ps_
    * module: _exceptions_

* Testing Code
    * Common Module
        * test module: _/_values_

    * Unit Test
        * test module: _/_utils.importing_
        * test module: _/_utils.cmd_ps_

    * Integration Test
        * test module: _run_cmd_


### _Effecting Scope_

* Provide new feature at option **_app-type_** to let the usage of command line could be more easier and clear.


### _Description_

* Add new utility functions about checking whether the target Python library could be import and use or not.
* Update the command line option info.
* Modify the implementation of running at subcommand line **_run_**.
* Add new exceptions.
* Add unit test and integration test for the new features.
