### PR TITLE
🎉🎊🍾 [New Feature] (code + test) Add new subcommand *check* for checking the validity of configuration.

### DIFF
--- a/pymock_api/cmd.py
+++ b/pymock_api/cmd.py
@@ -227,6 +227,7 @@ class SubCommand:
     Base: str = "subcommand"
     Run: str = "run"
     Config: str = "config"
+    Check: str = "check"
 
 
 class BaseSubCommand(CommandOption):
@@ -254,9 +255,17 @@ class SubCommandConfigOption(BaseSubCommand):
     )
 
 
+class SubCommandCheckOption(BaseSubCommand):
+    sub_parser: SubParserAttr = SubParserAttr(
+        name=SubCommand.Check,
+        help="Check the validity of *PyMock-API* configuration.",
+    )
+
+
 BaseCmdOption: type = MetaCommandOption("BaseCmdOption", (CommandOption,), {})
 BaseSubCmdRunOption: type = MetaCommandOption("BaseSubCmdRunOption", (SubCommandRunOption,), {})
 BaseSubCmdConfigOption: type = MetaCommandOption("BaseSubCmdConfigOption", (SubCommandConfigOption,), {})
+BaseSubCmdCheckOption: type = MetaCommandOption("BaseSubCmdCheckOption", (SubCommandCheckOption,), {})
 
 
 class Version(BaseCmdOption):
@@ -352,3 +361,10 @@ class Output(BaseSubCmdConfigOption):
     )
     option_value_type: type = str
     default_value: str = "sample-api.yaml"
+
+
+class ConfigPath(BaseSubCmdCheckOption):
+    cli_option: str = "-p, --config-path"
+    name: str = "config_path"
+    help_description: str = "The file path of configuration."
+    default_value: str = "api.yaml"

--- a/pymock_api/cmd_ps.py
+++ b/pymock_api/cmd_ps.py
@@ -193,12 +193,14 @@ class SubCmdCheck(BaseCommandProcessor):
     def _run(self, args: SubcmdCheckArguments) -> None:
         api_config: Optional[APIConfig] = load_config(path=args.config_path)
 
+        # # Check whether it has anything in configuration or not
         SubCmdCheck._setting_should_not_be_none(
             config_key="",
             config_value=api_config,
             err_msg="Configuration is empty.",
         )
 
+        # # Check first layer of configuration
         assert api_config is not None
         SubCmdCheck._setting_should_not_be_none(
             config_key="mocked_apis",
@@ -209,14 +211,15 @@ class SubCmdCheck(BaseCommandProcessor):
         # if it has anything within key *mocked_apis*.
         assert api_config.apis and api_config.apis.apis
 
+        # # Check each API content at first layer is *mocked_apis* of configuration
         for one_api_name, one_api_config in api_config.apis.apis.items():
-            # # Check first layer of configuration
+            # # Check second layer of configuration
             SubCmdCheck._setting_should_not_be_none(
                 config_key=f"mocked_apis.{one_api_name}",
                 config_value=one_api_config,
             )
 
-            # # Check second layer of configuration (not include the layer about API name, should be the first
+            # # Check third layer of configuration (not include the layer about API name, should be the first
             # # layer under API name)
             assert one_api_config
             SubCmdCheck._setting_should_not_be_none(
@@ -228,7 +231,7 @@ class SubCmdCheck(BaseCommandProcessor):
                 config_value=one_api_config.http,
             )
 
-            # # Check third layer of configuration
+            # # Check forth layer of configuration
             assert one_api_config.http
             SubCmdCheck._setting_should_not_be_none(
                 config_key=f"mocked_apis.{one_api_name}.http.request",

--- a/pymock_api/cmd_ps.py
+++ b/pymock_api/cmd_ps.py
@@ -5,7 +5,7 @@ import pathlib
 import re
 import sys
 from argparse import ArgumentParser, Namespace
-from typing import Any, Callable, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, List, Optional, Tuple, Type
 
 from ._utils import YAML, import_web_lib
 from .cmd import MockAPICommandParser, SubCommand
@@ -281,11 +281,12 @@ class SubCmdCheck(BaseCommandProcessor):
 
     @staticmethod
     def _setting_should_be_valid(
-        config_key: str, config_value: Any, criteria: Union[str, list], valid_callback: Optional[Callable] = None
+        config_key: str, config_value: Any, criteria: list, valid_callback: Optional[Callable] = None
     ) -> None:
-        if isinstance(criteria, str) and config_value != criteria:
-            is_valid = False
-        elif isinstance(criteria, list) and config_value not in criteria:
+        if not isinstance(criteria, list):
+            raise TypeError("The argument *criteria* only accept 'list' type value.")
+
+        if config_value not in criteria:
             is_valid = False
         else:
             is_valid = True

--- a/pymock_api/cmd_ps.py
+++ b/pymock_api/cmd_ps.py
@@ -1,6 +1,9 @@
 import copy
+import json
 import os
+import pathlib
 import re
+import sys
 from argparse import ArgumentParser, Namespace
 from typing import List, Optional, Tuple, Type
 
@@ -8,10 +11,13 @@ from ._utils import YAML, import_web_lib
 from .cmd import MockAPICommandParser, SubCommand
 from .exceptions import InvalidAppType, NoValidWebLibrary
 from .model import (
+    APIConfig,
     ParserArguments,
+    SubcmdCheckArguments,
     SubcmdConfigArguments,
     SubcmdRunArguments,
     deserialize_args,
+    load_config,
 )
 from .model._sample import Sample_Config_Value
 from .server import BaseSGIServer, setup_asgi, setup_wsgi
@@ -176,3 +182,80 @@ class SubCmdConfig(BaseCommandProcessor):
         if args.generate_sample:
             assert args.sample_output_path, _option_cannot_be_empty_assertion("-o, --output")
             yaml.write(path=args.sample_output_path, config=sample_data)
+
+
+class SubCmdCheck(BaseCommandProcessor):
+    responsible_subcommand = SubCommand.Check
+
+    def _parse_process(self, parser: ArgumentParser, cmd_args: Optional[List[str]] = None) -> SubcmdCheckArguments:
+        return deserialize_args.subcmd_check(self._parse_cmd_arguments(parser, cmd_args))
+
+    def _run(self, args: SubcmdCheckArguments) -> None:
+        print(f"[DEBUG] api_config: {args.config_path}")
+        api_config: Optional[APIConfig] = load_config(path=args.config_path)
+        print(f"[DEBUG] api_config: {api_config}")
+        if api_config is None:
+            print("Configuration *mocked_apis* is empty.")
+            sys.exit(1)
+
+        print(f"[DEBUG] api_config.apis: {api_config.apis}")
+        if api_config.apis:
+            if api_config.apis.apis is None:
+                print("Configuration *mocked_apis* is empty.")
+                sys.exit(1)
+
+            for one_api_name, one_api_config in api_config.apis.apis.items():
+                if one_api_config is None:
+                    print(f"Configuration *mocked_apis.{one_api_name}* content is empty.")
+                    sys.exit(1)
+
+                print(f"[DEBUG] one_api_config.url: {one_api_config.url}")
+                if one_api_config.url is None:
+                    print(f"Configuration *mocked_apis.{one_api_name}.url* content is empty.")
+                    sys.exit(1)
+
+                print(f"[DEBUG] one_api_config.http: {one_api_config.http}")
+                if one_api_config.http is None:
+                    print(f"Configuration *mocked_apis.{one_api_name}.http* content is empty.")
+                    sys.exit(1)
+
+                print(f"[DEBUG] one_api_config.http.request: {one_api_config.http.request}")
+                if one_api_config.http.request is None:
+                    print(f"Configuration *mocked_apis.{one_api_name}.http.request* content is empty.")
+                    sys.exit(1)
+
+                print(f"[DEBUG] one_api_config.http.request.method: {one_api_config.http.request.method}")
+                if one_api_config.http.request.method is None:
+                    print(f"Configuration *mocked_apis.{one_api_name}.http.request.method* content is empty.")
+                    sys.exit(1)
+
+                if one_api_config.http.request.method.upper() not in ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTION"]:
+                    print(f"Configuration *mocked_apis.{one_api_name}.http.request.method* content is empty.")
+                    sys.exit(1)
+
+                print(f"[DEBUG] one_api_config.http.response: {one_api_config.http.response}")
+                if one_api_config.http.response is None:
+                    print(f"Configuration *mocked_apis.{one_api_name}.http.response* content is empty.")
+                    sys.exit(1)
+
+                print(f"[DEBUG] one_api_config.http.response.value: {one_api_config.http.response.value}")
+                if one_api_config.http.response.value is None:
+                    print(f"Configuration *mocked_apis.{one_api_name}.http.response.value* content is empty.")
+                    sys.exit(1)
+
+                if one_api_config.http.response.value:
+                    try:
+                        json.loads(one_api_config.http.response.value)
+                    except:
+                        is_file_name_format = re.search(r"\w{1,32}\.\w{1,8}", one_api_config.http.response.value)
+                        print(f"[DEBUG] is_file_name_format: {is_file_name_format}")
+                        if is_file_name_format:
+                            if not pathlib.Path(one_api_config.http.response.value).exists():
+                                print("File doesn't exist")
+                                sys.exit(1)
+                        # else:
+                        #     print("Data content format is incorrect")
+                        #     sys.exit(1)
+
+        print("Configuration is valid.")
+        sys.exit(0)

--- a/pymock_api/cmd_ps.py
+++ b/pymock_api/cmd_ps.py
@@ -191,14 +191,11 @@ class SubCmdCheck(BaseCommandProcessor):
         return deserialize_args.subcmd_check(self._parse_cmd_arguments(parser, cmd_args))
 
     def _run(self, args: SubcmdCheckArguments) -> None:
-        print(f"[DEBUG] api_config: {args.config_path}")
         api_config: Optional[APIConfig] = load_config(path=args.config_path)
-        print(f"[DEBUG] api_config: {api_config}")
         if api_config is None:
             print("Configuration is empty.")
             sys.exit(1)
 
-        print(f"[DEBUG] api_config.apis: {api_config.apis}")
         if api_config.apis:
             # NOTE: It's the normal behavior of code implementation. It must have something of property *MockAPIs.apis*
             # if it has anything within key *mocked_apis*.
@@ -209,22 +206,18 @@ class SubCmdCheck(BaseCommandProcessor):
                     print(f"Configuration *mocked_apis.{one_api_name}* content is empty.")
                     sys.exit(1)
 
-                print(f"[DEBUG] one_api_config.url: {one_api_config.url}")
                 if one_api_config.url is None:
                     print(f"Configuration *mocked_apis.{one_api_name}.url* content is empty.")
                     sys.exit(1)
 
-                print(f"[DEBUG] one_api_config.http: {one_api_config.http}")
                 if one_api_config.http is None:
                     print(f"Configuration *mocked_apis.{one_api_name}.http* content is empty.")
                     sys.exit(1)
 
-                print(f"[DEBUG] one_api_config.http.request: {one_api_config.http.request}")
                 if one_api_config.http.request is None:
                     print(f"Configuration *mocked_apis.{one_api_name}.http.request* content is empty.")
                     sys.exit(1)
 
-                print(f"[DEBUG] one_api_config.http.request.method: {one_api_config.http.request.method}")
                 if one_api_config.http.request.method is None:
                     print(f"Configuration *mocked_apis.{one_api_name}.http.request.method* content is empty.")
                     sys.exit(1)
@@ -233,12 +226,10 @@ class SubCmdCheck(BaseCommandProcessor):
                     print(f"Configuration *mocked_apis.{one_api_name}.http.request.method* content is empty.")
                     sys.exit(1)
 
-                print(f"[DEBUG] one_api_config.http.response: {one_api_config.http.response}")
                 if one_api_config.http.response is None:
                     print(f"Configuration *mocked_apis.{one_api_name}.http.response* content is empty.")
                     sys.exit(1)
 
-                print(f"[DEBUG] one_api_config.http.response.value: {one_api_config.http.response.value}")
                 if one_api_config.http.response.value is None:
                     print(f"Configuration *mocked_apis.{one_api_name}.http.response.value* content is empty.")
                     sys.exit(1)
@@ -248,7 +239,6 @@ class SubCmdCheck(BaseCommandProcessor):
                         json.loads(one_api_config.http.response.value)
                     except:
                         is_file_name_format = re.search(r"\w{1,32}\.\w{1,8}", one_api_config.http.response.value)
-                        print(f"[DEBUG] is_file_name_format: {is_file_name_format}")
                         if is_file_name_format:
                             if not pathlib.Path(one_api_config.http.response.value).exists():
                                 print("File doesn't exist")

--- a/pymock_api/cmd_ps.py
+++ b/pymock_api/cmd_ps.py
@@ -200,9 +200,7 @@ class SubCmdCheck(BaseCommandProcessor):
 
         print(f"[DEBUG] api_config.apis: {api_config.apis}")
         if api_config.apis:
-            if api_config.apis.apis is None:
-                print("Configuration *mocked_apis* is empty.")
-                sys.exit(1)
+            assert api_config.apis.apis
 
             for one_api_name, one_api_config in api_config.apis.apis.items():
                 if one_api_config is None:

--- a/pymock_api/cmd_ps.py
+++ b/pymock_api/cmd_ps.py
@@ -256,6 +256,9 @@ class SubCmdCheck(BaseCommandProcessor):
                         # else:
                         #     print("Data content format is incorrect")
                         #     sys.exit(1)
+        else:
+            print("Configuration *mocked_apis* content is empty.")
+            sys.exit(1)
 
         print("Configuration is valid.")
         sys.exit(0)

--- a/pymock_api/cmd_ps.py
+++ b/pymock_api/cmd_ps.py
@@ -192,66 +192,71 @@ class SubCmdCheck(BaseCommandProcessor):
 
     def _run(self, args: SubcmdCheckArguments) -> None:
         api_config: Optional[APIConfig] = load_config(path=args.config_path)
-        if api_config is None:
-            print("Configuration is empty.")
-            sys.exit(1)
 
-        if api_config.apis:
-            # NOTE: It's the normal behavior of code implementation. It must have something of property *MockAPIs.apis*
-            # if it has anything within key *mocked_apis*.
-            assert api_config.apis.apis
+        SubCmdCheck._setting_should_not_be_none(
+            config_key="",
+            config_value=api_config,
+            err_msg="Configuration is empty.",
+        )
 
-            for one_api_name, one_api_config in api_config.apis.apis.items():
-                # # Check first layer of configuration
-                SubCmdCheck._setting_should_not_be_none(
-                    config_key=f"mocked_apis.{one_api_name}",
-                    config_value=one_api_config,
-                )
+        assert api_config is not None
+        SubCmdCheck._setting_should_not_be_none(
+            config_key="mocked_apis",
+            config_value=api_config.apis,
+        )
 
-                # # Check second layer of configuration (not include the layer about API name, should be the first
-                # # layer under API name)
-                assert one_api_config
-                SubCmdCheck._setting_should_not_be_none(
-                    config_key=f"mocked_apis.{one_api_name}.url",
-                    config_value=one_api_config.url,
-                )
-                SubCmdCheck._setting_should_not_be_none(
-                    config_key=f"mocked_apis.{one_api_name}.http",
-                    config_value=one_api_config.http,
-                )
+        # NOTE: It's the normal behavior of code implementation. It must have something of property *MockAPIs.apis*
+        # if it has anything within key *mocked_apis*.
+        assert api_config.apis and api_config.apis.apis
 
-                # # Check third layer of configuration
-                assert one_api_config.http
-                SubCmdCheck._setting_should_not_be_none(
-                    config_key=f"mocked_apis.{one_api_name}.http.request",
-                    config_value=one_api_config.http.request,
-                )
+        for one_api_name, one_api_config in api_config.apis.apis.items():
+            # # Check first layer of configuration
+            SubCmdCheck._setting_should_not_be_none(
+                config_key=f"mocked_apis.{one_api_name}",
+                config_value=one_api_config,
+            )
 
-                assert one_api_config.http.request
-                SubCmdCheck._setting_should_not_be_none(
-                    config_key=f"mocked_apis.{one_api_name}.http.request.method",
-                    config_value=one_api_config.http.request.method,
-                )
-                SubCmdCheck._setting_should_be_valid(
-                    config_key=f"mocked_apis.{one_api_name}.http.request.method",
-                    config_value=one_api_config.http.request.method.upper(),
-                    criteria=["GET", "POST", "PUT", "DELETE", "HEAD", "OPTION"],
-                )
+            # # Check second layer of configuration (not include the layer about API name, should be the first
+            # # layer under API name)
+            assert one_api_config
+            SubCmdCheck._setting_should_not_be_none(
+                config_key=f"mocked_apis.{one_api_name}.url",
+                config_value=one_api_config.url,
+            )
+            SubCmdCheck._setting_should_not_be_none(
+                config_key=f"mocked_apis.{one_api_name}.http",
+                config_value=one_api_config.http,
+            )
 
-                SubCmdCheck._setting_should_not_be_none(
-                    config_key=f"mocked_apis.{one_api_name}.http.response",
-                    config_value=one_api_config.http.response,
-                )
+            # # Check third layer of configuration
+            assert one_api_config.http
+            SubCmdCheck._setting_should_not_be_none(
+                config_key=f"mocked_apis.{one_api_name}.http.request",
+                config_value=one_api_config.http.request,
+            )
 
-                assert one_api_config.http.response
-                SubCmdCheck._setting_should_not_be_none(
-                    config_key=f"mocked_apis.{one_api_name}.http.response.value",
-                    config_value=one_api_config.http.response.value,
-                    valid_callback=self._chk_response_value_validity,
-                )
-        else:
-            print("Configuration *mocked_apis* content is empty.")
-            sys.exit(1)
+            assert one_api_config.http.request
+            SubCmdCheck._setting_should_not_be_none(
+                config_key=f"mocked_apis.{one_api_name}.http.request.method",
+                config_value=one_api_config.http.request.method,
+            )
+            SubCmdCheck._setting_should_be_valid(
+                config_key=f"mocked_apis.{one_api_name}.http.request.method",
+                config_value=one_api_config.http.request.method.upper(),
+                criteria=["GET", "POST", "PUT", "DELETE", "HEAD", "OPTION"],
+            )
+
+            SubCmdCheck._setting_should_not_be_none(
+                config_key=f"mocked_apis.{one_api_name}.http.response",
+                config_value=one_api_config.http.response,
+            )
+
+            assert one_api_config.http.response
+            SubCmdCheck._setting_should_not_be_none(
+                config_key=f"mocked_apis.{one_api_name}.http.response.value",
+                config_value=one_api_config.http.response.value,
+                valid_callback=self._chk_response_value_validity,
+            )
 
         print("Configuration is valid.")
         sys.exit(0)
@@ -270,10 +275,10 @@ class SubCmdCheck(BaseCommandProcessor):
 
     @staticmethod
     def _setting_should_not_be_none(
-        config_key: str, config_value: Any, valid_callback: Optional[Callable] = None
+        config_key: str, config_value: Any, valid_callback: Optional[Callable] = None, err_msg: Optional[str] = None
     ) -> None:
         if config_value is None:
-            print(f"Configuration *{config_key}* content cannot be empty.")
+            print(err_msg if err_msg else f"Configuration *{config_key}* content cannot be empty.")
             sys.exit(1)
         else:
             if valid_callback:

--- a/pymock_api/cmd_ps.py
+++ b/pymock_api/cmd_ps.py
@@ -200,6 +200,8 @@ class SubCmdCheck(BaseCommandProcessor):
 
         print(f"[DEBUG] api_config.apis: {api_config.apis}")
         if api_config.apis:
+            # NOTE: It's the normal behavior of code implementation. It must have something of property *MockAPIs.apis*
+            # if it has anything within key *mocked_apis*.
             assert api_config.apis.apis
 
             for one_api_name, one_api_config in api_config.apis.apis.items():

--- a/pymock_api/cmd_ps.py
+++ b/pymock_api/cmd_ps.py
@@ -223,25 +223,24 @@ class SubCmdCheck(BaseCommandProcessor):
                     sys.exit(1)
 
                 if one_api_config.http.request.method.upper() not in ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTION"]:
-                    print(f"Configuration *mocked_apis.{one_api_name}.http.request.method* content is empty.")
+                    print(f"Configuration *mocked_apis.{one_api_name}.http.request.method* value is invalid.")
                     sys.exit(1)
 
                 if one_api_config.http.response is None:
                     print(f"Configuration *mocked_apis.{one_api_name}.http.response* content is empty.")
                     sys.exit(1)
 
-                if one_api_config.http.response.value is None:
+                response_value = one_api_config.http.response.value
+                if response_value is None:
                     print(f"Configuration *mocked_apis.{one_api_name}.http.response.value* content is empty.")
                     sys.exit(1)
-
-                if one_api_config.http.response.value:
+                else:
                     try:
-                        json.loads(one_api_config.http.response.value)
+                        json.loads(response_value)
                     except:
-                        is_file_name_format = re.search(r"\w{1,32}\.\w{1,8}", one_api_config.http.response.value)
-                        if is_file_name_format:
-                            if not pathlib.Path(one_api_config.http.response.value).exists():
-                                print("File doesn't exist")
+                        if re.search(r"\w{1,32}\.\w{1,8}", response_value):
+                            if not pathlib.Path(response_value).exists():
+                                print("The file which is the response content doesn't exist.")
                                 sys.exit(1)
                         # else:
                         #     print("Data content format is incorrect")

--- a/pymock_api/cmd_ps.py
+++ b/pymock_api/cmd_ps.py
@@ -200,7 +200,7 @@ class SubCmdCheck(BaseCommandProcessor):
             err_msg="Configuration is empty.",
         )
 
-        # # Check first layer of configuration
+        # # Check the section *mocked_apis* (first layer) of configuration
         assert api_config is not None
         SubCmdCheck._setting_should_not_be_none(
             config_key="mocked_apis",
@@ -213,14 +213,14 @@ class SubCmdCheck(BaseCommandProcessor):
 
         # # Check each API content at first layer is *mocked_apis* of configuration
         for one_api_name, one_api_config in api_config.apis.apis.items():
-            # # Check second layer of configuration
+            # # Check the section *mocked_apis.<API name>* (second layer) of configuration
             SubCmdCheck._setting_should_not_be_none(
                 config_key=f"mocked_apis.{one_api_name}",
                 config_value=one_api_config,
             )
 
-            # # Check third layer of configuration (not include the layer about API name, should be the first
-            # # layer under API name)
+            # # Check the section *mocked_apis.<API name>.<property>* (third layer) of configuration (not include the
+            # # layer about API name, should be the first layer under API name)
             assert one_api_config
             SubCmdCheck._setting_should_not_be_none(
                 config_key=f"mocked_apis.{one_api_name}.url",
@@ -231,7 +231,7 @@ class SubCmdCheck(BaseCommandProcessor):
                 config_value=one_api_config.http,
             )
 
-            # # Check forth layer of configuration
+            # # Check the section *mocked_apis.<API name>.http.<property>* (forth layer) of configuration
             assert one_api_config.http
             SubCmdCheck._setting_should_not_be_none(
                 config_key=f"mocked_apis.{one_api_name}.http.request",

--- a/pymock_api/cmd_ps.py
+++ b/pymock_api/cmd_ps.py
@@ -195,7 +195,7 @@ class SubCmdCheck(BaseCommandProcessor):
         api_config: Optional[APIConfig] = load_config(path=args.config_path)
         print(f"[DEBUG] api_config: {api_config}")
         if api_config is None:
-            print("Configuration *mocked_apis* is empty.")
+            print("Configuration is empty.")
             sys.exit(1)
 
         print(f"[DEBUG] api_config.apis: {api_config.apis}")

--- a/pymock_api/model/__init__.py
+++ b/pymock_api/model/__init__.py
@@ -10,6 +10,7 @@ from .api_config import APIConfig
 from .cmd_args import (
     DeserializeParsedArgs,
     ParserArguments,
+    SubcmdCheckArguments,
     SubcmdConfigArguments,
     SubcmdRunArguments,
 )
@@ -41,6 +42,19 @@ class deserialize_args:
 
         """
         return DeserializeParsedArgs.subcommand_config(args)
+
+    @classmethod
+    def subcmd_check(cls, args: Namespace) -> SubcmdCheckArguments:
+        """Deserialize the object *argparse.Namespace* to *ParserArguments*.
+
+        Args:
+            args (Namespace): The arguments which be parsed from current command line.
+
+        Returns:
+            A *ParserArguments* type object.
+
+        """
+        return DeserializeParsedArgs.subcommand_check(args)
 
 
 def load_config(path: str) -> Optional[APIConfig]:

--- a/pymock_api/model/cmd_args.py
+++ b/pymock_api/model/cmd_args.py
@@ -1,5 +1,5 @@
 from argparse import Namespace
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 
 

--- a/pymock_api/model/cmd_args.py
+++ b/pymock_api/model/cmd_args.py
@@ -26,6 +26,11 @@ class SubcmdConfigArguments(ParserArguments):
     sample_output_path: str
 
 
+@dataclass(frozen=True)
+class SubcmdCheckArguments(ParserArguments):
+    config_path: str
+
+
 class DeserializeParsedArgs:
     """*Deserialize the object *argparse.Namespace* to *ParserArguments*"""
 
@@ -47,4 +52,11 @@ class DeserializeParsedArgs:
             generate_sample=args.generate_sample,
             print_sample=args.print_sample,
             sample_output_path=args.file_path,
+        )
+
+    @classmethod
+    def subcommand_check(cls, args: Namespace) -> SubcmdCheckArguments:
+        return SubcmdCheckArguments(
+            subparser_name=args.subcommand,
+            config_path=args.config_path,
         )

--- a/test/_values.py
+++ b/test/_values.py
@@ -108,3 +108,6 @@ _Test_SubCommand_Config: str = "config"
 _Generate_Sample: bool = True
 _Print_Sample: bool = True
 _Sample_File_Path: str = "pytest-api.yaml"
+
+# Test subcommand *check* options
+_Test_SubCommand_Check: str = "check"

--- a/test/config/invalid/mockapis_api_name_http_request_method-with_invalid_value.yaml
+++ b/test/config/invalid/mockapis_api_name_http_request_method-with_invalid_value.yaml
@@ -1,0 +1,8 @@
+mocked_apis:
+  google_home:
+    url: '/google'
+    http:
+      request:
+        method: 'INVALID'
+      response:
+        value: 'This is Google home API.'

--- a/test/config/invalid/mockapis_api_name_http_response_value-with_not_exist_file.yaml
+++ b/test/config/invalid/mockapis_api_name_http_response_value-with_not_exist_file.yaml
@@ -1,0 +1,8 @@
+mocked_apis:
+  google_home:
+    url: '/google'
+    http:
+      request:
+        method: 'GET'
+      response:
+        value: ./not_exist.file

--- a/test/config/invalid/no_mockapis.yaml
+++ b/test/config/invalid/no_mockapis.yaml
@@ -1,0 +1,1 @@
+mocked_apis:

--- a/test/config/invalid/no_mockapis_api_name.yaml
+++ b/test/config/invalid/no_mockapis_api_name.yaml
@@ -1,0 +1,2 @@
+mocked_apis:
+  google_home:

--- a/test/config/invalid/no_mockapis_api_name_http.yaml
+++ b/test/config/invalid/no_mockapis_api_name_http.yaml
@@ -1,0 +1,4 @@
+mocked_apis:
+  google_home:
+    url: '/google'
+    http:

--- a/test/config/invalid/no_mockapis_api_name_http_request.yaml
+++ b/test/config/invalid/no_mockapis_api_name_http_request.yaml
@@ -1,0 +1,7 @@
+mocked_apis:
+  google_home:
+    url: '/google'
+    http:
+      request:
+      response:
+        value: 'This is Google home API.'

--- a/test/config/invalid/no_mockapis_api_name_http_request_method.yaml
+++ b/test/config/invalid/no_mockapis_api_name_http_request_method.yaml
@@ -1,0 +1,8 @@
+mocked_apis:
+  google_home:
+    url: '/google'
+    http:
+      request:
+        method:
+      response:
+        value: 'This is Google home API.'

--- a/test/config/invalid/no_mockapis_api_name_http_response.yaml
+++ b/test/config/invalid/no_mockapis_api_name_http_response.yaml
@@ -1,0 +1,7 @@
+mocked_apis:
+  google_home:
+    url: '/google'
+    http:
+      request:
+        method: 'GET'
+      response:

--- a/test/config/invalid/no_mockapis_api_name_http_response_value.yaml
+++ b/test/config/invalid/no_mockapis_api_name_http_response_value.yaml
@@ -1,0 +1,8 @@
+mocked_apis:
+  google_home:
+    url: '/google'
+    http:
+      request:
+        method: 'GET'
+      response:
+        value:

--- a/test/config/invalid/no_mockapis_api_name_url.yaml
+++ b/test/config/invalid/no_mockapis_api_name_url.yaml
@@ -1,2 +1,3 @@
 mocked_apis:
   google_home:
+    url:

--- a/test/config/invalid/no_mockapis_api_name_url.yaml
+++ b/test/config/invalid/no_mockapis_api_name_url.yaml
@@ -1,0 +1,2 @@
+mocked_apis:
+  google_home:

--- a/test/config/valid/sample-with_general_string_value.yaml
+++ b/test/config/valid/sample-with_general_string_value.yaml
@@ -1,0 +1,8 @@
+mocked_apis:
+  google_home:
+    url: '/google'
+    http:
+      request:
+        method: 'GET'
+      response:
+        value: 'This is Google home.'

--- a/test/integration_test/runner.py
+++ b/test/integration_test/runner.py
@@ -60,9 +60,10 @@ class TestHelp(CommandFunctionTestSpec):
         self._should_contains_chars_in_result(cmd_running_result, "-h, --help")
         self._should_contains_chars_in_result(cmd_running_result, "-v, --version")
         self._should_contains_chars_in_result(cmd_running_result, "Subcommands:")
-        self._should_contains_chars_in_result(cmd_running_result, "{run,config}")
+        self._should_contains_chars_in_result(cmd_running_result, "{run,config,check}")
         self._should_contains_chars_in_result(cmd_running_result, "run")
         self._should_contains_chars_in_result(cmd_running_result, "config")
+        self._should_contains_chars_in_result(cmd_running_result, "check")
 
 
 class TestVersion(CommandFunctionTestSpec):

--- a/test/unit_test/cmd_ps.py
+++ b/test/unit_test/cmd_ps.py
@@ -1,3 +1,6 @@
+import glob
+import os.path
+import pathlib
 import re
 from abc import ABCMeta, abstractmethod
 from argparse import ArgumentParser, Namespace
@@ -11,12 +14,18 @@ from pymock_api.cmd import SubCommand, get_all_subcommands
 from pymock_api.cmd_ps import (
     BaseCommandProcessor,
     NoSubCmd,
+    SubCmdCheck,
     SubCmdConfig,
     SubCmdRun,
     make_command_chain,
     run_command_chain,
 )
-from pymock_api.model import ParserArguments, SubcmdConfigArguments, SubcmdRunArguments
+from pymock_api.model import (
+    ParserArguments,
+    SubcmdCheckArguments,
+    SubcmdConfigArguments,
+    SubcmdRunArguments,
+)
 from pymock_api.server import ASGIServer, Command, CommandOptions, WSGIServer
 
 from .._values import (
@@ -29,6 +38,7 @@ from .._values import (
     _Test_Auto_Type,
     _Test_Config,
     _Test_FastAPI_App_Type,
+    _Test_SubCommand_Check,
     _Test_SubCommand_Config,
     _Test_SubCommand_Run,
     _Workers_Amount,
@@ -41,7 +51,7 @@ _Fake_Amt: int = 1
 
 
 def _given_parser_args(
-    subcommand: str = None, app_type: str = None
+    subcommand: str = None, app_type: str = None, config_path: str = None
 ) -> Union[SubcmdRunArguments, SubcmdConfigArguments, ParserArguments]:
     if subcommand == "run":
         return SubcmdRunArguments(
@@ -58,6 +68,11 @@ def _given_parser_args(
             print_sample=_Print_Sample,
             generate_sample=_Generate_Sample,
             sample_output_path=_Sample_File_Path,
+        )
+    elif subcommand == "check":
+        return SubcmdCheckArguments(
+            subparser_name=subcommand,
+            config_path=(config_path or _Test_Config),
         )
     else:
         return ParserArguments(
@@ -457,6 +472,68 @@ class TestSubCmdConfig(BaseCommandProcessorTestSpec):
             mock_instantiate_writer.assert_called_once()
             FakeYAML.serialize.assert_called_once()
             FakeYAML.write.assert_not_called()
+
+
+API_NAME: str = "google_home"
+INVALID_YAML: List[str] = []
+
+
+def _get_all_invalid_yaml() -> None:
+    invalid_yaml_dir = os.path.join(str(pathlib.Path(__file__).parent.parent), "config", "invalid", "*.yaml")
+    global INVALID_YAML
+    INVALID_YAML = glob.glob(invalid_yaml_dir)
+
+
+def _expected_err_msg(file: str) -> str:
+    file = file.split("/")[-1] if "/" in file else file
+    file_name: List[str] = file.split("-")
+    config_key = file_name[0].replace("no_", "").replace(".yaml", "").replace("_", ".").replace("api.name", API_NAME)
+    return f"Configuration *{config_key}* content"
+
+
+_get_all_invalid_yaml()
+
+
+class TestSubCmdCheck(BaseCommandProcessorTestSpec):
+    @pytest.fixture(scope="function")
+    def cmd_ps(self) -> SubCmdCheck:
+        return SubCmdCheck()
+
+    @pytest.mark.parametrize("config_path", INVALID_YAML)
+    def test_with_command_processor(self, config_path: str, object_under_test: Callable):
+        kwargs = {
+            "config_path": config_path,
+            "cmd_ps": object_under_test,
+        }
+        self._test_process(**kwargs)
+
+    @pytest.mark.parametrize("config_path", INVALID_YAML)
+    def test_with_run_entry_point(self, config_path: str, entry_point_under_test: Callable):
+        kwargs = {
+            "config_path": config_path,
+            "cmd_ps": entry_point_under_test,
+        }
+        self._test_process(**kwargs)
+
+    def _test_process(self, config_path: str, cmd_ps: Callable):
+        mock_parser_arg = _given_parser_args(subcommand=_Test_SubCommand_Check, config_path=config_path)
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_ps(mock_parser_arg)
+        _expected_sys_exit_code = "1"
+        assert _expected_sys_exit_code in str(exc_info.value)
+        # TODO: Add one more checking of the error message content with function *_expected_err_msg*
+
+    def _given_cmd_args_namespace(self) -> Namespace:
+        args_namespace = Namespace()
+        args_namespace.subcommand = SubCommand.Check
+        args_namespace.config_path = _Test_Config
+        return args_namespace
+
+    def _given_subcmd(self) -> Optional[str]:
+        return SubCommand.Check
+
+    def _expected_argument_type(self) -> Type[SubcmdCheckArguments]:
+        return SubcmdCheckArguments
 
 
 def test_make_command_chain():

--- a/test/unit_test/cmd_ps.py
+++ b/test/unit_test/cmd_ps.py
@@ -481,7 +481,7 @@ TEST_YAML_PATHS: List[str] = []
 def _get_all_yaml(config_type: str) -> None:
     yaml_dir = os.path.join(str(pathlib.Path(__file__).parent.parent), "config", config_type, "*.yaml")
     global TEST_YAML_PATHS
-    TEST_YAML_PATHS = glob.glob(yaml_dir)
+    TEST_YAML_PATHS.extend(glob.glob(yaml_dir))
 
 
 def _expected_err_msg(file: str) -> str:

--- a/test/unit_test/cmd_ps.py
+++ b/test/unit_test/cmd_ps.py
@@ -546,6 +546,20 @@ class TestSubCmdCheck(BaseCommandProcessorTestSpec):
     def _expected_argument_type(self) -> Type[SubcmdCheckArguments]:
         return SubcmdCheckArguments
 
+    def test__setting_should_be_valid(self, cmd_ps: SubCmdCheck):
+        test_callback = MagicMock()
+        cmd_ps._setting_should_be_valid(
+            config_key="key", config_value="value", criteria=["value"], valid_callback=test_callback
+        )
+        test_callback.assert_called_once_with("key", "value", ["value"])
+
+    def test__setting_should_be_valid_with_invalid_type_criteria(self, cmd_ps: SubCmdCheck):
+        with pytest.raises(TypeError) as exc_info:
+            cmd_ps._setting_should_be_valid(
+                config_key="any key", config_value="any value", criteria="invalid type value"
+            )
+        assert re.search(r"only accept 'list'", str(exc_info.value), re.IGNORECASE)
+
 
 def test_make_command_chain():
     assert len(get_all_subcommands()) == len(make_command_chain()) - _No_SubCmd_Amt - _Fake_Amt

--- a/test/unit_test/cmd_ps.py
+++ b/test/unit_test/cmd_ps.py
@@ -478,8 +478,8 @@ API_NAME: str = "google_home"
 INVALID_YAML: List[str] = []
 
 
-def _get_all_invalid_yaml() -> None:
-    invalid_yaml_dir = os.path.join(str(pathlib.Path(__file__).parent.parent), "config", "invalid", "*.yaml")
+def _get_all_invalid_yaml(config_type: str = "invalid") -> None:
+    invalid_yaml_dir = os.path.join(str(pathlib.Path(__file__).parent.parent), "config", config_type, "*.yaml")
     global INVALID_YAML
     INVALID_YAML = glob.glob(invalid_yaml_dir)
 

--- a/test/unit_test/cmd_ps.py
+++ b/test/unit_test/cmd_ps.py
@@ -475,13 +475,13 @@ class TestSubCmdConfig(BaseCommandProcessorTestSpec):
 
 
 API_NAME: str = "google_home"
-INVALID_YAML: List[str] = []
+TEST_YAML_PATHS: List[str] = []
 
 
-def _get_all_invalid_yaml(config_type: str = "invalid") -> None:
-    invalid_yaml_dir = os.path.join(str(pathlib.Path(__file__).parent.parent), "config", config_type, "*.yaml")
-    global INVALID_YAML
-    INVALID_YAML = glob.glob(invalid_yaml_dir)
+def _get_all_yaml(config_type: str) -> None:
+    yaml_dir = os.path.join(str(pathlib.Path(__file__).parent.parent), "config", config_type, "*.yaml")
+    global TEST_YAML_PATHS
+    TEST_YAML_PATHS = glob.glob(yaml_dir)
 
 
 def _expected_err_msg(file: str) -> str:
@@ -491,7 +491,7 @@ def _expected_err_msg(file: str) -> str:
     return f"Configuration *{config_key}* content"
 
 
-_get_all_invalid_yaml()
+_get_all_yaml(config_type="invalid")
 
 
 class TestSubCmdCheck(BaseCommandProcessorTestSpec):
@@ -499,7 +499,7 @@ class TestSubCmdCheck(BaseCommandProcessorTestSpec):
     def cmd_ps(self) -> SubCmdCheck:
         return SubCmdCheck()
 
-    @pytest.mark.parametrize("config_path", INVALID_YAML)
+    @pytest.mark.parametrize("config_path", TEST_YAML_PATHS)
     def test_with_command_processor(self, config_path: str, object_under_test: Callable):
         kwargs = {
             "config_path": config_path,
@@ -507,7 +507,7 @@ class TestSubCmdCheck(BaseCommandProcessorTestSpec):
         }
         self._test_process(**kwargs)
 
-    @pytest.mark.parametrize("config_path", INVALID_YAML)
+    @pytest.mark.parametrize("config_path", TEST_YAML_PATHS)
     def test_with_run_entry_point(self, config_path: str, entry_point_under_test: Callable):
         kwargs = {
             "config_path": config_path,

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -92,7 +92,7 @@ class ConfigTestSpec(metaclass=ABCMeta):
         pass
 
     def test_deserialize_with_invalid_data(self, sut_with_nothing: _Config):
-        assert sut_with_nothing.deserialize(data={}) is None
+        assert sut_with_nothing.deserialize(data={}) == {}
 
 
 class TestAPIConfig(ConfigTestSpec):
@@ -358,12 +358,11 @@ class TestMockAPIs(ConfigTestSpec):
     def test_deserialize_with_nonideal_value(
         self, mock_deserialize_base: Mock, mock_deserialize_mock_api: Mock, test_data: dict, sut_with_nothing: MockAPIs
     ):
-        assert sut_with_nothing.deserialize(data=test_data) is None
+        assert sut_with_nothing.deserialize(data=test_data) is not None
+        mock_deserialize_base.assert_called_once_with(data="base_info")
         if len(test_data.keys()) > 1:
-            mock_deserialize_base.assert_called_once_with(data="base_info")
             mock_deserialize_mock_api.assert_called_once_with(data="api_info")
         else:
-            mock_deserialize_base.assert_not_called()
             mock_deserialize_mock_api.assert_not_called()
 
     def _expected_serialize_value(self) -> Any:

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -31,6 +31,25 @@ _assertion_msg = "Its property's value should be same as we set."
 MOCK_RETURN_VALUE: Mock = Mock()
 
 
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        (None, None),
+        ({}, {}),
+        ({"any_key": "any_value"}, {"any_key": "any_value", "flag": "has run *test_function*"}),
+    ],
+)
+def test_ensure_process_with_not_empty_value(data: Optional[Dict[str, str]], expected: Optional[Dict[str, str]]):
+    class FakeObject:
+        @_Config._ensure_process_with_not_empty_value
+        def test_function(self, data: Dict[str, Any]) -> Any:
+            data["flag"] = "has run *test_function*"
+            return data
+
+    fo = FakeObject()
+    assert fo.test_function(data=data) == expected
+
+
 def test_config_get_prop():
     class FakeConfig(_Config):
         def _compare(self, other: "_Config") -> bool:

--- a/test/unit_test/model/cmd_args.py
+++ b/test/unit_test/model/cmd_args.py
@@ -5,6 +5,7 @@ import pytest
 
 from pymock_api.model.cmd_args import (
     DeserializeParsedArgs,
+    SubcmdCheckArguments,
     SubcmdConfigArguments,
     SubcmdRunArguments,
 )
@@ -17,6 +18,7 @@ from ..._values import (
     _Sample_File_Path,
     _Test_App_Type,
     _Test_Config,
+    _Test_SubCommand_Check,
     _Test_SubCommand_Config,
     _Test_SubCommand_Run,
     _Workers_Amount,
@@ -61,3 +63,14 @@ class TestDeserialize:
         assert arguments.generate_sample == _Generate_Sample
         assert arguments.print_sample == _Print_Sample
         assert arguments.sample_output_path == _Sample_File_Path
+
+    def test_parser_subcommand_check_arguments(self, deserialize: Type[DeserializeParsedArgs]):
+        namespace_args = {
+            "subcommand": _Test_SubCommand_Check,
+            "config_path": _Test_Config,
+        }
+        namespace = Namespace(**namespace_args)
+        arguments = deserialize.subcommand_check(namespace)
+        assert isinstance(arguments, SubcmdCheckArguments)
+        assert arguments.subparser_name == _Test_SubCommand_Check
+        assert arguments.config_path == _Test_Config

--- a/test/unit_test/model/init.py
+++ b/test/unit_test/model/init.py
@@ -11,6 +11,7 @@ from ..._values import (
     _Sample_File_Path,
     _Test_App_Type,
     _Test_Config,
+    _Test_SubCommand_Check,
     _Test_SubCommand_Config,
     _Test_SubCommand_Run,
     _Workers_Amount,
@@ -42,4 +43,15 @@ def test_deserialize_subcommand_config_args(mock_parser_arguments: Mock):
     }
     namespace = Namespace(**namespace_args)
     deserialize_args.subcmd_config(namespace)
+    mock_parser_arguments.assert_called_once_with(namespace)
+
+
+@patch.object(DeserializeParsedArgs, "subcommand_check")
+def test_deserialize_subcommand_check_args(mock_parser_arguments: Mock):
+    namespace_args = {
+        "subcommand": _Test_SubCommand_Check,
+        "config_path": _Test_Config,
+    }
+    namespace = Namespace(**namespace_args)
+    deserialize_args.subcmd_check(namespace)
     mock_parser_arguments.assert_called_once_with(namespace)


### PR DESCRIPTION
### _Target_

* Add new subcommand **_check_** for checking the validity of configuration.

```shell
>>> mock-api check --help
usage: mock-api check [-h] [-p CONFIG_PATH]

options:
  -h, --help            show this help message and exit
  -p CONFIG_PATH, --config-path CONFIG_PATH
                        The file path of configuration. [default: 'api.yaml']
```


### _Modify Code Scope_

* Source Code
    * module _cmd_
    * module _cmd_ps_
    * sub-package _model_

* Testing Code
    * Configuration for testing
        * directory _config/invalid_
        * directory _config/valid_
    * Common Module
        * module _/_values_
    * Unit Test
        * module _cmd_ps_
        * module _model.api_config_
        * module _model.cmd_args_
        * module _model.init_
    * Integration Test
        * module _runner_


### _Effecting Scope_

* Provides new feature about new subcommand **_check_** of command line tool.


### _Description_

* Add new subcommand and command options.
* Add new data class about command line option arguments for new subcommand.
* Add subcommand process.
* Add unit test and integration test for this new feature.
