### PR TITLE
🛠🐛💣 [Bug Fix] (test) Fix issue about error *TypeError: 'classmethod' object is not callable* under Python version 3.10.

### DIFF
--- a/pymock_api/model/api_config.py
+++ b/pymock_api/model/api_config.py
@@ -52,7 +52,6 @@ class _Config(metaclass=ABCMeta):
         return _
 
     @abstractmethod
-    @_ensure_process_with_not_empty_value
     def deserialize(self, data: Dict[str, Any]) -> Optional[SelfType]:
         pass
 


### PR DESCRIPTION
### _Target_

* Fix issue about error *TypeError: 'classmethod' object is not callable* under Python version 3.10.
    * Error scenario: using decorator which be implemented as static method or class method.


### _Modify Code Scope_

* Source Code
    * module _model.api_config_


### _Effecting Scope_

* Fix issue of decorator usage when the source code runs under Python version 3.10.


### _Description_

* Remove the decorator usage at function in the class where the decorator is in.
