### PR TITLE
🎉🎊🍾 [New Feature] Implement the core logic of subcommand line *get*.

### DIFF
--- a/pymock_api/command/get/component.py
+++ b/pymock_api/command/get/component.py
@@ -1,3 +1,5 @@
+import sys
+
 from ...model import load_config
 from ...model.cmd_args import SubcmdGetArguments
 from ..component import BaseSubCmdComponent
@@ -6,4 +8,39 @@ from ..component import BaseSubCmdComponent
 class SubCmdGetComponent(BaseSubCmdComponent):
     def process(self, args: SubcmdGetArguments) -> None:  # type: ignore[override]
         current_api_config = load_config(path=args.config_path)
+        if current_api_config is None:
+            print("❌  Empty content in configuration file.")
+            sys.exit(1)
+        apis_info = current_api_config.apis
+        if apis_info is None:
+            print("❌  Cannot find any API setting to mock.")
+            sys.exit(1)
+        specific_api_info = apis_info.get_api_config_by_url(url=args.api_path, base=apis_info.base)
+        if specific_api_info:
+            print("🍻  Find the API info which satisfy the conditions.")
+            print("+--------------- API info ---------------+")
+            print(f"+ Path:  {specific_api_info.url}")
+            print(f"+ HTTP:")
+            http_info = specific_api_info.http
+            print("+   Request:")
+            if http_info and http_info.request:
+                print(f"+     HTTP method:  {http_info.request.method}")
+                print("+       Parameters:")
+                for param in http_info.request.parameters:
+                    print(f"+         name:  {param.name}")
+                    print(f"+           required:  {param.required}")
+                    print(f"+           default value:  {param.default}")
+                    print(f"+           data type:  {param.value_type}")
+                    print(f"+           value format:  {param.value_format}")
+            else:
+                print("+     Miss settings.")
+            print("+     Response:")
+            if http_info and http_info.response:
+                print(f"+       Values:  {http_info.response.value}")
+            else:
+                print("+     Miss settings.")
+            sys.exit(0)
+        else:
+            print("🙅‍♂️  Cannot find the API info with the conditions.")
+            sys.exit(1)
         # TODO: Add implementation about *inspect* feature gets some details of config

--- a/pymock_api/command/get/component.py
+++ b/pymock_api/command/get/component.py
@@ -46,4 +46,3 @@ class SubCmdGetComponent(BaseSubCmdComponent):
         else:
             print("🙅‍♂️  Cannot find the API info with the conditions.")
             sys.exit(1)
-        # TODO: Add implementation about *inspect* feature gets some details of config

--- a/pymock_api/command/get/component.py
+++ b/pymock_api/command/get/component.py
@@ -23,22 +23,25 @@ class SubCmdGetComponent(BaseSubCmdComponent):
             print("+ HTTP:")
             http_info = specific_api_info.http
             print("+   Request:")
-            if http_info and http_info.request:
-                print(f"+     HTTP method:  {http_info.request.method}")
-                print("+       Parameters:")
-                for param in http_info.request.parameters:
-                    print(f"+         name:  {param.name}")
-                    print(f"+           required:  {param.required}")
-                    print(f"+           default value:  {param.default}")
-                    print(f"+           data type:  {param.value_type}")
-                    print(f"+           value format:  {param.value_format}")
+            if http_info:
+                if http_info.request:
+                    print(f"+     HTTP method:  {http_info.request.method}")
+                    print("+       Parameters:")
+                    for param in http_info.request.parameters:
+                        print(f"+         name:  {param.name}")
+                        print(f"+           required:  {param.required}")
+                        print(f"+           default value:  {param.default}")
+                        print(f"+           data type:  {param.value_type}")
+                        print(f"+           value format:  {param.value_format}")
+                else:
+                    print("+     Miss HTTP request settings.")
+                print("+     Response:")
+                if http_info.response:
+                    print(f"+       Values:  {http_info.response.value}")
+                else:
+                    print("+     Miss HTTP response settings.")
             else:
-                print("+     Miss settings.")
-            print("+     Response:")
-            if http_info and http_info.response:
-                print(f"+       Values:  {http_info.response.value}")
-            else:
-                print("+     Miss settings.")
+                print("+     Miss HTTP settings.")
             sys.exit(0)
         else:
             print("🙅‍♂️  Cannot find the API info with the conditions.")

--- a/pymock_api/command/get/component.py
+++ b/pymock_api/command/get/component.py
@@ -20,7 +20,7 @@ class SubCmdGetComponent(BaseSubCmdComponent):
             print("🍻  Find the API info which satisfy the conditions.")
             print("+--------------- API info ---------------+")
             print(f"+ Path:  {specific_api_info.url}")
-            print(f"+ HTTP:")
+            print("+ HTTP:")
             http_info = specific_api_info.http
             print("+   Request:")
             if http_info and http_info.request:

--- a/pymock_api/command/options.py
+++ b/pymock_api/command/options.py
@@ -435,3 +435,18 @@ class UnderCheckConfigPath(BaseSubCmdGetOption):
     name: str = "config_path"
     help_description: str = "The file path of configuration."
     default_value: str = "api.yaml"
+
+
+class GetAPIPath(BaseSubCmdGetOption):
+    cli_option: str = "-a, --api-path"
+    name: str = "api_path"
+    help_description: str = "Get the API info by API path."
+
+
+class GetWithHTTPMethod(BaseSubCmdGetOption):
+    cli_option: str = "-m, --http-method"
+    name: str = "http_method"
+    help_description: str = (
+        "This is an option for searching condition which cannot be used individually. Add "
+        "condition of HTTP method to get the API info."
+    )

--- a/pymock_api/model/cmd_args.py
+++ b/pymock_api/model/cmd_args.py
@@ -39,6 +39,8 @@ class SubcmdCheckArguments(ParserArguments):
 @dataclass(frozen=True)
 class SubcmdGetArguments(ParserArguments):
     config_path: str
+    api_path: str
+    http_method: str
 
 
 class DeserializeParsedArgs:
@@ -85,4 +87,6 @@ class DeserializeParsedArgs:
         return SubcmdGetArguments(
             subparser_name=args.subcommand,
             config_path=args.config_path,
+            api_path=args.api_path,
+            http_method=args.http_method,
         )

--- a/test/_values.py
+++ b/test/_values.py
@@ -165,3 +165,5 @@ _Test_SubCommand_Check: str = "check"
 # Test subcommand *inspect* options
 _Test_SubCommand_Get: str = "get"
 _Swagger_API_Document_URL: str = "Swagger API document URL"
+_Cmd_Arg_API_Path: str = "/foo-home"
+_Cmd_Arg_HTTP_Method: str = "GET"

--- a/test/data/get_test/invalid/error/empty-mock-apis.yaml
+++ b/test/data/get_test/invalid/error/empty-mock-apis.yaml
@@ -1,0 +1,1 @@
+mocked_apis:

--- a/test/data/get_test/invalid/warn/empty-http-request.yaml
+++ b/test/data/get_test/invalid/warn/empty-http-request.yaml
@@ -1,0 +1,7 @@
+mocked_apis:
+  foo_home:
+    url: '/foo-home'
+    http:
+      request:
+      response:
+        value: 'This is Foo home API.'

--- a/test/data/get_test/invalid/warn/empty-http-response.yaml
+++ b/test/data/get_test/invalid/warn/empty-http-response.yaml
@@ -1,0 +1,20 @@
+mocked_apis:
+  foo_home:
+    url: '/foo-home'
+    http:
+      request:
+        method: 'GET'
+        parameters:
+          - name: 'arg1'
+            required: false
+            type: str
+            default: 'arg1_default_value'
+          - name: 'arg2'
+            required: false
+            type: int
+            default: 0
+          - name: 'arg3'
+            required: false
+            type: bool
+            default: false
+      response:

--- a/test/data/get_test/invalid/warn/empty-http.yaml
+++ b/test/data/get_test/invalid/warn/empty-http.yaml
@@ -1,0 +1,4 @@
+mocked_apis:
+  foo_home:
+    url: '/foo-home'
+    http:

--- a/test/data/get_test/valid/simple.yaml
+++ b/test/data/get_test/valid/simple.yaml
@@ -1,0 +1,21 @@
+mocked_apis:
+  foo_home:
+    url: '/foo-home'
+    http:
+      request:
+        method: 'GET'
+        parameters:
+          - name: 'arg1'
+            required: false
+            type: str
+            default: 'arg1_default_value'
+          - name: 'arg2'
+            required: false
+            type: int
+            default: 0
+          - name: 'arg3'
+            required: false
+            type: bool
+            default: false
+      response:
+        value: 'This is Foo home API.'

--- a/test/unit_test/command/process.py
+++ b/test/unit_test/command/process.py
@@ -528,8 +528,29 @@ class TestSubCmdCheck(BaseCommandProcessorTestSpec):
 GET_YAML_PATHS_WITH_EX_CODE: List[tuple] = []
 
 
-def _get_all_yaml_for_subcmd_get(get_api_path: str, exit_code: Union[str, int]) -> None:
-    yaml_dir = os.path.join(str(pathlib.Path(__file__).parent.parent.parent), "data", "get_test", "valid", "*.yaml")
+def _get_all_yaml_for_subcmd_get(
+    get_api_path: str, is_valid_config: bool, exit_code: Union[str, int], acceptable_error: bool = None
+) -> None:
+    is_valid_path = "valid" if is_valid_config else "invalid"
+    if is_valid_config is False and acceptable_error is not None:
+        config_folder = "warn" if acceptable_error else "error"
+        entire_config_path = (
+            str(pathlib.Path(__file__).parent.parent.parent),
+            "data",
+            "get_test",
+            is_valid_path,
+            config_folder,
+            "*.yaml",
+        )
+    else:
+        entire_config_path = (
+            str(pathlib.Path(__file__).parent.parent.parent),
+            "data",
+            "get_test",
+            is_valid_path,
+            "*.yaml",
+        )
+    yaml_dir = os.path.join(*entire_config_path)
     global GET_YAML_PATHS_WITH_EX_CODE
     for yaml_config_path in glob.glob(yaml_dir):
         expected_exit_code = exit_code if isinstance(exit_code, str) and exit_code.isdigit() else str(exit_code)
@@ -537,8 +558,15 @@ def _get_all_yaml_for_subcmd_get(get_api_path: str, exit_code: Union[str, int]) 
         GET_YAML_PATHS_WITH_EX_CODE.append(one_test_scenario)
 
 
-_get_all_yaml_for_subcmd_get("/foo-home", 0)
-_get_all_yaml_for_subcmd_get("/not-exist-api", 1)
+# With valid configuration
+_get_all_yaml_for_subcmd_get(get_api_path="/foo-home", is_valid_config=True, exit_code=0)
+_get_all_yaml_for_subcmd_get(get_api_path="/not-exist-api", is_valid_config=True, exit_code=1)
+
+# With invalid configuration
+_get_all_yaml_for_subcmd_get(get_api_path="/foo-home", is_valid_config=False, acceptable_error=True, exit_code=0)
+_get_all_yaml_for_subcmd_get(get_api_path="/foo-home", is_valid_config=False, acceptable_error=False, exit_code=1)
+_get_all_yaml_for_subcmd_get(get_api_path="/not-exist-api", is_valid_config=False, acceptable_error=True, exit_code=1)
+_get_all_yaml_for_subcmd_get(get_api_path="/not-exist-api", is_valid_config=False, acceptable_error=False, exit_code=1)
 
 
 class TestSubCmdGet(BaseCommandProcessorTestSpec):

--- a/test/unit_test/command/process.py
+++ b/test/unit_test/command/process.py
@@ -32,6 +32,8 @@ from pymock_api.server import ASGIServer, Command, CommandOptions, WSGIServer
 
 from ..._values import (
     _Bind_Host_And_Port,
+    _Cmd_Arg_API_Path,
+    _Cmd_Arg_HTTP_Method,
     _Generate_Sample,
     _Log_Level,
     _Print_Sample,
@@ -90,6 +92,8 @@ def _given_parser_args(
         return SubcmdGetArguments(
             subparser_name=subcommand,
             config_path=(config_path or _Test_Config),
+            api_path=_Cmd_Arg_API_Path,
+            http_method=_Cmd_Arg_HTTP_Method,
         )
     else:
         return ParserArguments(
@@ -548,6 +552,8 @@ class TestSubCmdGet(BaseCommandProcessorTestSpec):
         args_namespace = Namespace()
         args_namespace.subcommand = SubCommand.Get
         args_namespace.config_path = _Test_Config
+        args_namespace.api_path = _Cmd_Arg_API_Path
+        args_namespace.http_method = _Cmd_Arg_HTTP_Method
         return args_namespace
 
     def _given_subcmd(self) -> Optional[str]:

--- a/test/unit_test/model/cmd_args.py
+++ b/test/unit_test/model/cmd_args.py
@@ -14,6 +14,8 @@ from pymock_api.model.cmd_args import (
 
 from ..._values import (
     _Bind_Host_And_Port,
+    _Cmd_Arg_API_Path,
+    _Cmd_Arg_HTTP_Method,
     _Generate_Sample,
     _Log_Level,
     _Print_Sample,
@@ -145,9 +147,13 @@ class TestDeserialize:
         namespace_args = {
             "subcommand": _Test_SubCommand_Get,
             "config_path": _Test_Config,
+            "api_path": _Cmd_Arg_API_Path,
+            "http_method": _Cmd_Arg_HTTP_Method,
         }
         namespace = Namespace(**namespace_args)
         arguments = deserialize.subcommand_get(namespace)
         assert isinstance(arguments, SubcmdGetArguments)
         assert arguments.subparser_name == _Test_SubCommand_Get
         assert arguments.config_path == _Test_Config
+        assert arguments.api_path == _Cmd_Arg_API_Path
+        assert arguments.http_method == _Cmd_Arg_HTTP_Method


### PR DESCRIPTION
### _Target_

* Implement the core logic of subcommand line **_get_**.
* Example usage:
```console
>>> mock-api get -p ./demo-api.yaml -a /foo-home                                                                                                                    🍻  Find the API info which satisfy the conditions.
+--------------- API info ---------------+
+ Path:  /foo-home
+ HTTP:
+   Request:
+     HTTP method:  GET
+       Parameters:
+         name:  arg1
...
```


### _Modify Code Scope_

* Source Code
    * module _command.options_
    * module _command.get.component_
    * module _model.cmd_args_

* Testing
    * Data
        * directory _data/get_test_

    * Common module
        * module _/_values_

    * Unit Test
        * module _command.process_
        * module _model.cmd_args_


### _Effecting Scope_

* Provide new feature about subcommand line **_get_**.


### _Description_

* Implement the core logic of subcommand line **_get_**.
* Add the unit test for the implementation.
