### PR TITLE
🎉🎊🍾 [New Feature] Add new command line options of subcommand *add*.

### DIFF
--- a/pymock_api/command/add/component.py
+++ b/pymock_api/command/add/component.py
@@ -28,15 +28,18 @@ class SubCmdAddComponent(BaseSubCmdComponent):
             if not args.api_info_is_complete():
                 print(f"❌  API info is not enough to add new API.")
                 sys.exit(1)
-            if os.path.exists(args.api_config_path):
-                api_config = load_config(args.api_config_path)
-                if not api_config:
-                    api_config = generate_empty_config()
-            else:
-                api_config = generate_empty_config()
-
+            api_config = self._get_api_config(args)
             api_config = self._generate_api_config(api_config, args)
             yaml.write(path=args.api_config_path, config=api_config.serialize())  # type: ignore[arg-type]
+
+    def _get_api_config(self, args: SubcmdAddArguments) -> APIConfig:
+        if os.path.exists(args.api_config_path):
+            api_config = load_config(args.api_config_path)
+            if not api_config:
+                api_config = generate_empty_config()
+        else:
+            api_config = generate_empty_config()
+        return api_config
 
     def _generate_api_config(self, api_config: APIConfig, args: SubcmdAddArguments) -> APIConfig:
         assert api_config.apis is not None

--- a/pymock_api/command/add/component.py
+++ b/pymock_api/command/add/component.py
@@ -35,13 +35,17 @@ class SubCmdAddComponent(BaseSubCmdComponent):
             else:
                 api_config = generate_empty_config()
 
-            assert api_config.apis
+            assert api_config.apis is not None
             base = api_config.apis.base
             mocked_api = MockAPI()
             if args.api_path:
                 mocked_api.url = args.api_path.replace(base.url, "") if base else args.api_path
             if args.http_method or args.parameters:
-                mocked_api.set_request(method=args.http_method, parameters=args.parameters)
+                try:
+                    mocked_api.set_request(method=args.http_method, parameters=args.parameters)
+                except ValueError:
+                    print("❌  The data format of API parameter is incorrect.")
+                    sys.exit(1)
                 # mocked_api.http.request.method = args.http_method
             # if args.parameters:
             #     mocked_api.http.request.parameters = args.parameters

--- a/pymock_api/command/add/component.py
+++ b/pymock_api/command/add/component.py
@@ -35,18 +35,22 @@ class SubCmdAddComponent(BaseSubCmdComponent):
             else:
                 api_config = generate_empty_config()
 
-            assert api_config.apis is not None
-            base = api_config.apis.base
-            mocked_api = MockAPI()
-            if args.api_path:
-                mocked_api.url = args.api_path.replace(base.url, "") if base else args.api_path
-            if args.http_method or args.parameters:
-                try:
-                    mocked_api.set_request(method=args.http_method, parameters=args.parameters)
-                except ValueError:
-                    print("❌  The data format of API parameter is incorrect.")
-                    sys.exit(1)
-            if args.response:
-                mocked_api.set_response(value=args.response)
-            api_config.apis.apis[args.api_path] = mocked_api
+            api_config = self._generate_api_config(api_config, args)
             yaml.write(path=args.api_config_path, config=api_config.serialize())  # type: ignore[arg-type]
+
+    def _generate_api_config(self, api_config: APIConfig, args: SubcmdAddArguments) -> APIConfig:
+        assert api_config.apis is not None
+        base = api_config.apis.base
+        mocked_api = MockAPI()
+        if args.api_path:
+            mocked_api.url = args.api_path.replace(base.url, "") if base else args.api_path
+        if args.http_method or args.parameters:
+            try:
+                mocked_api.set_request(method=args.http_method, parameters=args.parameters)
+            except ValueError:
+                print("❌  The data format of API parameter is incorrect.")
+                sys.exit(1)
+        if args.response:
+            mocked_api.set_response(value=args.response)
+        api_config.apis.apis[args.api_path] = mocked_api
+        return api_config

--- a/pymock_api/command/add/component.py
+++ b/pymock_api/command/add/component.py
@@ -15,6 +15,7 @@ def _option_cannot_be_empty_assertion(cmd_option: str) -> str:
 
 class SubCmdAddComponent(BaseSubCmdComponent):
     def process(self, args: SubcmdAddArguments) -> None:  # type: ignore[override]
+        # TODO: Add logic about using mapping file operation by the file extension.
         yaml: YAML = YAML()
         sample_data: str = yaml.serialize(config=Sample_Config_Value)
         if args.print_sample:

--- a/pymock_api/command/add/component.py
+++ b/pymock_api/command/add/component.py
@@ -46,11 +46,7 @@ class SubCmdAddComponent(BaseSubCmdComponent):
                 except ValueError:
                     print("❌  The data format of API parameter is incorrect.")
                     sys.exit(1)
-                # mocked_api.http.request.method = args.http_method
-            # if args.parameters:
-            #     mocked_api.http.request.parameters = args.parameters
             if args.response:
                 mocked_api.set_response(value=args.response)
-                # mocked_api.http.response.value = args.response
             api_config.apis.apis[args.api_path] = mocked_api
             yaml.write(path=args.api_config_path, config=api_config.serialize())  # type: ignore[arg-type]

--- a/pymock_api/command/options.py
+++ b/pymock_api/command/options.py
@@ -372,6 +372,46 @@ class Output(BaseSubCmdAddOption):
     default_value: str = "sample-api.yaml"
 
 
+class APIConfigPath(BaseSubCmdAddOption):
+    cli_option: str = "--api-config-path"
+    name: str = "api_config_path"
+    help_description: str = "The configuration file path."
+    option_value_type: type = str
+    default_value: str = "api.yaml"
+
+
+class AddAPIPath(BaseSubCmdAddOption):
+    cli_option: str = "--api-path"
+    name: str = "api_path"
+    help_description: str = "Set URL path of one specific API."
+    option_value_type: type = str
+
+
+class AddHTTPMethod(BaseSubCmdAddOption):
+    cli_option: str = "--http-method"
+    name: str = "http_method"
+    help_description: str = "Set HTTP method of one specific API."
+    option_value_type: type = str
+    default_value: str = "GET"
+
+
+class AddParameters(BaseSubCmdAddOption):
+    cli_option: str = "--parameters"
+    name: str = "parameters"
+    help_description: str = "Set HTTP request parameter(s) of one specific API."
+    action: str = "append"
+    option_value_type: type = str
+    default_value: str = ""
+
+
+class AddResponse(BaseSubCmdAddOption):
+    cli_option: str = "--response"
+    name: str = "response"
+    help_description: str = "Set HTTP response value of one specific API."
+    option_value_type: type = str
+    default_value: str = "OK."
+
+
 class ConfigPath(BaseSubCmdCheckOption):
     cli_option: str = "-p, --config-path"
     name: str = "config_path"

--- a/pymock_api/model/__init__.py
+++ b/pymock_api/model/__init__.py
@@ -6,7 +6,16 @@ content ...
 from argparse import Namespace
 from typing import Optional
 
-from .api_config import APIConfig
+from .api_config import (
+    HTTP,
+    APIConfig,
+    APIParameter,
+    BaseConfig,
+    HTTPRequest,
+    HTTPResponse,
+    MockAPI,
+    MockAPIs,
+)
 from .cmd_args import (
     DeserializeParsedArgs,
     ParserArguments,
@@ -78,3 +87,7 @@ def deserialize_swagger_api_config(data: dict) -> SwaggerConfig:
 
 def load_config(path: str) -> Optional[APIConfig]:
     return APIConfig().from_yaml(path=path)
+
+
+def generate_empty_config(name: str = "", description: str = "") -> APIConfig:
+    return APIConfig(name=name, description=description, apis=MockAPIs(base=BaseConfig(url=""), apis={}))

--- a/pymock_api/model/api_config.py
+++ b/pymock_api/model/api_config.py
@@ -432,8 +432,6 @@ class MockAPI(_Config):
             ap_data_obj_fields.append("type")
             if False in list(map(lambda p: p in ap_data_obj_fields, param.keys())):
                 raise ValueError("The data format of API parameter is incorrect.")
-                # print("❌  The data format of API parameter is incorrect.")
-                # sys.exit(1)
             return ap.deserialize(param)
 
         params = list(map(_convert, parameters)) if parameters else []

--- a/pymock_api/model/api_config.py
+++ b/pymock_api/model/api_config.py
@@ -2,7 +2,7 @@
 
 content ...
 """
-
+import sys
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Union
@@ -423,6 +423,40 @@ class MockAPI(_Config):
         http_info = data.get("http", None)
         self.http = HTTP().deserialize(data=http_info) if http_info else None
         return self
+
+    def set_request(self, method: str = "GET", parameters: Optional[List[dict]] = None) -> None:
+        def _convert(param: dict) -> APIParameter:
+            ap = APIParameter()
+            ap_data_obj_fields = list(ap.__dataclass_fields__.keys())
+            ap_data_obj_fields.pop(ap_data_obj_fields.index("value_type"))
+            ap_data_obj_fields.append("type")
+            if False in list(map(lambda p: p in ap_data_obj_fields, param.keys())):
+                raise ValueError("The data format of API parameter is incorrect.")
+                # print("❌  The data format of API parameter is incorrect.")
+                # sys.exit(1)
+            return ap.deserialize(param)
+
+        params = list(map(_convert, parameters)) if parameters else []
+        if not self.http:
+            self.http = HTTP(request=HTTPRequest(method=method, parameters=params), response=HTTPResponse())
+        else:
+            if not self.http.request:
+                self.http.request = HTTPRequest(method=method, parameters=params)
+            else:
+                if method:
+                    self.http.request.method = method
+                if parameters:
+                    self.http.request.parameters = params
+
+    def set_response(self, value: str = "") -> None:
+        if not self.http:
+            self.http = HTTP(request=HTTPRequest(), response=HTTPResponse(value=value))
+        else:
+            if not self.http.response:
+                self.http.response = HTTPResponse(value=value)
+            else:
+                if value:
+                    self.http.response.value = value
 
     def format(self, f: Format) -> str:
         def _ensure_getting_serialized_data() -> Dict[str, Any]:

--- a/pymock_api/model/api_config.py
+++ b/pymock_api/model/api_config.py
@@ -673,7 +673,7 @@ class APIConfig(_Config):
         name = (data.name if data else None) or self.name
         description = (data.description if data else None) or self.description
         apis = (data.apis if data else None) or self.apis
-        if not (name and description and apis):
+        if not apis:
             return None
         return {
             "name": name,

--- a/pymock_api/model/cmd_args.py
+++ b/pymock_api/model/cmd_args.py
@@ -1,6 +1,7 @@
+import json
 from argparse import Namespace
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional
 
 from ..model.enums import Format
 
@@ -26,6 +27,21 @@ class SubcmdAddArguments(ParserArguments):
     generate_sample: bool
     print_sample: bool
     sample_output_path: str
+    api_config_path: str
+    api_path: str
+    http_method: str
+    parameters: List[dict]
+    response: str
+
+    def api_info_is_complete(self) -> bool:
+        def _string_is_not_empty(s: Optional[str]) -> bool:
+            if s is not None:
+                s = s.replace(" ", "")
+                return s != ""
+            return False
+
+        string_chksum = list(map(_string_is_not_empty, [self.api_config_path, self.api_path]))
+        return False not in string_chksum
 
 
 @dataclass(frozen=True)
@@ -63,11 +79,18 @@ class DeserializeParsedArgs:
 
     @classmethod
     def subcommand_add(cls, args: Namespace) -> SubcmdAddArguments:
+        if args.parameters:
+            args.parameters = list(map(lambda p: json.loads(p), args.parameters))
         return SubcmdAddArguments(
             subparser_name=args.subcommand,
             generate_sample=args.generate_sample,
             print_sample=args.print_sample,
             sample_output_path=args.file_path,
+            api_config_path=args.api_config_path,
+            api_path=args.api_path,
+            http_method=args.http_method,
+            parameters=args.parameters,
+            response=args.response,
         )
 
     @classmethod

--- a/test/unit_test/command/add/component.py
+++ b/test/unit_test/command/add/component.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from pymock_api import APIConfig
 from pymock_api._utils.file_opt import YAML
 from pymock_api.command.add.component import SubCmdAddComponent
 from pymock_api.model import MockAPI, generate_empty_config
@@ -55,6 +56,53 @@ class TestSubCmdConfigComponent:
             mock_instantiate_writer.assert_called_once()
             FakeYAML.serialize.assert_called_once()
             FakeYAML.write.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("file_exist", "load_config_result"),
+        [
+            (False, None),
+            (True, generate_empty_config()),
+            (True, None),
+        ],
+    )
+    def test_get_api_config(
+        self, file_exist: bool, load_config_result: Optional[APIConfig], component: SubCmdAddComponent
+    ):
+        # Mock functions
+        FakeYAML.serialize = MagicMock()
+        FakeYAML.write = MagicMock()
+        component._generate_api_config = MagicMock()
+
+        with patch("pymock_api.command.add.component.YAML", return_value=FakeYAML) as mock_instantiate_writer:
+            with patch(
+                "pymock_api.command.add.component.load_config", return_value=load_config_result
+            ) as mock_load_config:
+                with patch("pymock_api.command.add.component.generate_empty_config") as mock_generate_empty_config:
+                    with patch("os.path.exists", return_value=file_exist) as mock_path_exist:
+                        args = SubcmdAddArguments(
+                            subparser_name=_Test_SubCommand_Add,
+                            print_sample=False,
+                            generate_sample=False,
+                            sample_output_path="",
+                            api_config_path=_Test_Config,
+                            api_path=_Test_URL,
+                            http_method="GET",
+                            parameters=[],
+                            response="OK",
+                        )
+                        component.process(args)
+
+                        mock_instantiate_writer.assert_called_once()
+                        mock_path_exist.assert_called_once_with(_Test_Config)
+                        if file_exist:
+                            mock_load_config.assert_called_once_with(_Test_Config)
+                            if load_config_result:
+                                mock_generate_empty_config.assert_not_called()
+                            else:
+                                mock_generate_empty_config.assert_called_once()
+                        else:
+                            mock_load_config.assert_not_called()
+                            mock_generate_empty_config.assert_called_once()
 
     @pytest.mark.parametrize(
         ("http_method", "parameters", "response"),

--- a/test/unit_test/command/add/component.py
+++ b/test/unit_test/command/add/component.py
@@ -68,43 +68,32 @@ class TestSubCmdConfigComponent:
     def test_get_api_config(
         self, file_exist: bool, load_config_result: Optional[APIConfig], component: SubCmdAddComponent
     ):
-        # Mock functions
-        FakeYAML.serialize = MagicMock()
-        FakeYAML.write = MagicMock()
+        with patch("pymock_api.command.add.component.load_config", return_value=load_config_result) as mock_load_config:
+            with patch("pymock_api.command.add.component.generate_empty_config") as mock_generate_empty_config:
+                with patch("os.path.exists", return_value=file_exist) as mock_path_exist:
+                    args = SubcmdAddArguments(
+                        subparser_name=_Test_SubCommand_Add,
+                        print_sample=False,
+                        generate_sample=False,
+                        sample_output_path="",
+                        api_config_path=_Test_Config,
+                        api_path=_Test_URL,
+                        http_method="GET",
+                        parameters=[],
+                        response="OK",
+                    )
+                    component._get_api_config(args)
 
-        with patch("pymock_api.command.add.component.YAML", return_value=FakeYAML) as mock_instantiate_writer:
-            with patch(
-                "pymock_api.command.add.component.load_config", return_value=load_config_result
-            ) as mock_load_config:
-                with patch("pymock_api.command.add.component.generate_empty_config") as mock_generate_empty_config:
-                    with patch.object(component, "_generate_api_config") as mock__generate_api_config:
-                        with patch("os.path.exists", return_value=file_exist) as mock_path_exist:
-                            args = SubcmdAddArguments(
-                                subparser_name=_Test_SubCommand_Add,
-                                print_sample=False,
-                                generate_sample=False,
-                                sample_output_path="",
-                                api_config_path=_Test_Config,
-                                api_path=_Test_URL,
-                                http_method="GET",
-                                parameters=[],
-                                response="OK",
-                            )
-                            component.process(args)
-
-                            mock_instantiate_writer.assert_called_once()
-                            mock_path_exist.assert_called_once_with(_Test_Config)
-                            if file_exist:
-                                mock_load_config.assert_called_once_with(_Test_Config)
-                                if load_config_result:
-                                    mock_generate_empty_config.assert_not_called()
-                                else:
-                                    mock_generate_empty_config.assert_called_once()
-                            else:
-                                mock_load_config.assert_not_called()
-                                mock_generate_empty_config.assert_called_once()
-                            mock__generate_api_config.assert_called_once()
-                            FakeYAML.write.assert_called_once()
+                    mock_path_exist.assert_called_once_with(_Test_Config)
+                    if file_exist:
+                        mock_load_config.assert_called_once_with(_Test_Config)
+                        if load_config_result:
+                            mock_generate_empty_config.assert_not_called()
+                        else:
+                            mock_generate_empty_config.assert_called_once()
+                    else:
+                        mock_load_config.assert_not_called()
+                        mock_generate_empty_config.assert_called_once()
 
     @pytest.mark.parametrize(
         ("http_method", "parameters", "response"),

--- a/test/unit_test/command/add/component.py
+++ b/test/unit_test/command/add/component.py
@@ -1,13 +1,22 @@
 import re
+from typing import List, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from pymock_api._utils.file_opt import YAML
 from pymock_api.command.add.component import SubCmdAddComponent
+from pymock_api.model import MockAPI, generate_empty_config
 from pymock_api.model.cmd_args import SubcmdAddArguments
 
-from ...._values import _Test_SubCommand_Add
+from ...._values import (
+    _Test_Config,
+    _Test_HTTP_Method,
+    _Test_HTTP_Resp,
+    _Test_SubCommand_Add,
+    _Test_URL,
+    _TestConfig,
+)
 
 
 class FakeYAML(YAML):
@@ -29,6 +38,11 @@ class TestSubCmdConfigComponent:
             print_sample=False,
             generate_sample=True,
             sample_output_path="",
+            api_config_path="",
+            api_path="",
+            http_method="",
+            parameters=[],
+            response="",
         )
 
         # Run target function to test
@@ -41,3 +55,51 @@ class TestSubCmdConfigComponent:
             mock_instantiate_writer.assert_called_once()
             FakeYAML.serialize.assert_called_once()
             FakeYAML.write.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("http_method", "parameters", "response"),
+        [
+            (None, [], None),
+            (
+                "POST",
+                [{"name": "arg1", "required": False, "default": "val1", "type": "str"}],
+                "This is PyTest response",
+            ),
+        ],
+    )
+    def test_add_valid_api(
+        self, http_method: Optional[str], parameters: List[dict], response: Optional[str], component: SubCmdAddComponent
+    ):
+        # Mock functions
+        FakeYAML.serialize = MagicMock()
+        FakeYAML.write = MagicMock()
+
+        with patch("pymock_api.command.add.component.YAML", return_value=FakeYAML) as mock_instantiate_writer:
+            with patch("os.path.exists", return_value=False) as mock_path_exist:
+                args = SubcmdAddArguments(
+                    subparser_name=_Test_SubCommand_Add,
+                    print_sample=False,
+                    generate_sample=False,
+                    sample_output_path="",
+                    api_config_path=_Test_Config,
+                    api_path=_Test_URL,
+                    http_method=http_method,
+                    parameters=parameters,
+                    response=response,
+                )
+                component.process(args)
+
+                default_http_method: str = "GET"
+                default_http_response: str = "OK"
+
+                api_config = generate_empty_config()
+                mocked_api = MockAPI()
+                if http_method or parameters:
+                    mocked_api.set_request(method=(http_method or default_http_method), parameters=parameters)
+                if response:
+                    mocked_api.set_response(value=(response or default_http_response))
+                api_config.apis.apis[_Test_URL] = mocked_api
+
+                mock_path_exist.assert_called_once_with(_Test_Config)
+                mock_instantiate_writer.assert_called_once()
+                FakeYAML.write.assert_called_once_with(path=_Test_Config, config=api_config.serialize())

--- a/test/unit_test/command/add/component.py
+++ b/test/unit_test/command/add/component.py
@@ -71,40 +71,40 @@ class TestSubCmdConfigComponent:
         # Mock functions
         FakeYAML.serialize = MagicMock()
         FakeYAML.write = MagicMock()
-        component._generate_api_config = MagicMock()
 
         with patch("pymock_api.command.add.component.YAML", return_value=FakeYAML) as mock_instantiate_writer:
             with patch(
                 "pymock_api.command.add.component.load_config", return_value=load_config_result
             ) as mock_load_config:
                 with patch("pymock_api.command.add.component.generate_empty_config") as mock_generate_empty_config:
-                    with patch("os.path.exists", return_value=file_exist) as mock_path_exist:
-                        args = SubcmdAddArguments(
-                            subparser_name=_Test_SubCommand_Add,
-                            print_sample=False,
-                            generate_sample=False,
-                            sample_output_path="",
-                            api_config_path=_Test_Config,
-                            api_path=_Test_URL,
-                            http_method="GET",
-                            parameters=[],
-                            response="OK",
-                        )
-                        component.process(args)
+                    with patch.object(component, "_generate_api_config") as mock__generate_api_config:
+                        with patch("os.path.exists", return_value=file_exist) as mock_path_exist:
+                            args = SubcmdAddArguments(
+                                subparser_name=_Test_SubCommand_Add,
+                                print_sample=False,
+                                generate_sample=False,
+                                sample_output_path="",
+                                api_config_path=_Test_Config,
+                                api_path=_Test_URL,
+                                http_method="GET",
+                                parameters=[],
+                                response="OK",
+                            )
+                            component.process(args)
 
-                        mock_instantiate_writer.assert_called_once()
-                        mock_path_exist.assert_called_once_with(_Test_Config)
-                        if file_exist:
-                            mock_load_config.assert_called_once_with(_Test_Config)
-                            if load_config_result:
-                                mock_generate_empty_config.assert_not_called()
+                            mock_instantiate_writer.assert_called_once()
+                            mock_path_exist.assert_called_once_with(_Test_Config)
+                            if file_exist:
+                                mock_load_config.assert_called_once_with(_Test_Config)
+                                if load_config_result:
+                                    mock_generate_empty_config.assert_not_called()
+                                else:
+                                    mock_generate_empty_config.assert_called_once()
                             else:
+                                mock_load_config.assert_not_called()
                                 mock_generate_empty_config.assert_called_once()
-                        else:
-                            mock_load_config.assert_not_called()
-                            mock_generate_empty_config.assert_called_once()
-                        component._generate_api_config.assert_called_once()
-                        FakeYAML.write.assert_called_once()
+                            mock__generate_api_config.assert_called_once()
+                            FakeYAML.write.assert_called_once()
 
     @pytest.mark.parametrize(
         ("http_method", "parameters", "response"),

--- a/test/unit_test/command/add/component.py
+++ b/test/unit_test/command/add/component.py
@@ -103,6 +103,8 @@ class TestSubCmdConfigComponent:
                         else:
                             mock_load_config.assert_not_called()
                             mock_generate_empty_config.assert_called_once()
+                        component._generate_api_config.assert_called_once()
+                        FakeYAML.write.assert_called_once()
 
     @pytest.mark.parametrize(
         ("http_method", "parameters", "response"),
@@ -137,16 +139,8 @@ class TestSubCmdConfigComponent:
                 )
                 component.process(args)
 
-                default_http_method: str = "GET"
-                default_http_response: str = "OK"
-
                 api_config = generate_empty_config()
-                mocked_api = MockAPI()
-                if http_method or parameters:
-                    mocked_api.set_request(method=(http_method or default_http_method), parameters=parameters)
-                if response:
-                    mocked_api.set_response(value=(response or default_http_response))
-                api_config.apis.apis[_Test_URL] = mocked_api
+                api_config = component._generate_api_config(api_config, args)
 
                 mock_path_exist.assert_called_once_with(_Test_Config)
                 mock_instantiate_writer.assert_called_once()

--- a/test/unit_test/command/process.py
+++ b/test/unit_test/command/process.py
@@ -44,10 +44,13 @@ from ..._values import (
     _Test_Auto_Type,
     _Test_Config,
     _Test_FastAPI_App_Type,
+    _Test_HTTP_Method,
+    _Test_HTTP_Resp,
     _Test_SubCommand_Add,
     _Test_SubCommand_Check,
     _Test_SubCommand_Get,
     _Test_SubCommand_Run,
+    _Test_URL,
     _Workers_Amount,
 )
 
@@ -80,6 +83,11 @@ def _given_parser_args(
             print_sample=_Print_Sample,
             generate_sample=_Generate_Sample,
             sample_output_path=_Sample_File_Path,
+            api_config_path=_Sample_File_Path,
+            api_path=_Test_URL,
+            http_method=_Test_HTTP_Method,
+            parameters="",
+            response=_Test_HTTP_Resp,
         )
     elif subcommand == "check":
         return SubcmdCheckArguments(
@@ -406,6 +414,11 @@ class TestSubCmdAdd(BaseCommandProcessorTestSpec):
             print_sample=oprint,
             generate_sample=generate,
             sample_output_path=output,
+            api_config_path="",
+            api_path=_Test_URL,
+            http_method=_Test_HTTP_Method,
+            parameters=[],
+            response=_Test_HTTP_Resp,
         )
 
         with patch("builtins.print", autospec=True, side_effect=print) as mock_print:
@@ -431,6 +444,11 @@ class TestSubCmdAdd(BaseCommandProcessorTestSpec):
         args_namespace.generate_sample = _Generate_Sample
         args_namespace.print_sample = _Print_Sample
         args_namespace.file_path = _Sample_File_Path
+        args_namespace.api_config_path = ""
+        args_namespace.api_path = _Test_URL
+        args_namespace.http_method = _Test_HTTP_Method
+        args_namespace.parameters = ""
+        args_namespace.response = _Test_HTTP_Resp
         return args_namespace
 
     def _given_subcmd(self) -> Optional[str]:

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -481,7 +481,7 @@ class TestMockAPI(ConfigTestSpec):
         assert re.search(r".{0,64}not support.{0,64}" + re.escape(invalid_format), str(exc_info.value), re.IGNORECASE)
 
     @pytest.mark.parametrize("http_req", [None, HTTP(), HTTP(request=HTTPRequest())])
-    def test_set_request(self, http_req: Optional[HTTPRequest], sut_with_nothing: MockAPI):
+    def test_set_valid_request(self, http_req: Optional[HTTPRequest], sut_with_nothing: MockAPI):
         # Pro-process
         sut_with_nothing.http = http_req
 

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -480,6 +480,36 @@ class TestMockAPI(ConfigTestSpec):
             sut.format(invalid_format)
         assert re.search(r".{0,64}not support.{0,64}" + re.escape(invalid_format), str(exc_info.value), re.IGNORECASE)
 
+    @pytest.mark.parametrize("http_req", [None, HTTP(), HTTP(request=HTTPRequest())])
+    def test_set_request(self, http_req: Optional[HTTPRequest], sut_with_nothing: MockAPI):
+        # Pro-process
+        sut_with_nothing.http = http_req
+
+        assert sut_with_nothing.http == http_req
+        ut_method = "POST"
+        ut_parameters = [{"name": "arg1", "required": False, "default": "val1", "type": "str"}]
+        sut_with_nothing.set_request(method=ut_method, parameters=ut_parameters)
+
+        assert sut_with_nothing.http
+        assert sut_with_nothing.http.request
+        assert sut_with_nothing.http.request.method == ut_method
+        assert sut_with_nothing.http.request.parameters == [
+            APIParameter(name="arg1", required=False, default="val1", value_type="str")
+        ]
+
+    @pytest.mark.parametrize("http_resp", [None, HTTP(), HTTP(response=HTTPResponse())])
+    def test_set_response(self, http_resp: Optional[HTTPResponse], sut_with_nothing: MockAPI):
+        # Pro-process
+        sut_with_nothing.http = http_resp
+
+        assert sut_with_nothing.http == http_resp
+        ut_value = "PyTest response"
+        sut_with_nothing.set_response(value=ut_value)
+
+        assert sut_with_nothing.http
+        assert sut_with_nothing.http.response
+        assert sut_with_nothing.http.response.value == ut_value
+
 
 class TestHTTP(ConfigTestSpec):
     @pytest.fixture(scope="function")

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -497,6 +497,20 @@ class TestMockAPI(ConfigTestSpec):
             APIParameter(name="arg1", required=False, default="val1", value_type="str")
         ]
 
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {"name": "arg1", "required": False, "default": "val1", "type": "str", "invalid_key": ""},
+            {"name": "arg1", "required": False, "default": "val1", "value_type": "str"},
+        ],
+    )
+    def test_set_invalid_request(self, params: dict, sut_with_nothing: MockAPI):
+        ut_method = "POST"
+        ut_parameters = [params]
+        with pytest.raises(ValueError) as exc_info:
+            sut_with_nothing.set_request(method=ut_method, parameters=ut_parameters)
+        assert re.search(r".{1,64}format.{1,64}is incorrect.{1,64}", str(exc_info.value), re.IGNORECASE)
+
     @pytest.mark.parametrize("http_resp", [None, HTTP(), HTTP(response=HTTPResponse())])
     def test_set_response(self, http_resp: Optional[HTTPResponse], sut_with_nothing: MockAPI):
         # Pro-process

--- a/test/unit_test/model/cmd_args.py
+++ b/test/unit_test/model/cmd_args.py
@@ -25,10 +25,13 @@ from ..._values import (
     _Swagger_API_Document_URL,
     _Test_App_Type,
     _Test_Config,
+    _Test_HTTP_Method,
+    _Test_HTTP_Resp,
     _Test_SubCommand_Add,
     _Test_SubCommand_Check,
     _Test_SubCommand_Get,
     _Test_SubCommand_Run,
+    _Test_URL,
     _Workers_Amount,
 )
 
@@ -66,6 +69,11 @@ class TestDeserialize:
             "generate_sample": _Generate_Sample,
             "print_sample": _Print_Sample,
             "file_path": _Sample_File_Path,
+            "api_config_path": _Sample_File_Path,
+            "api_path": _Test_URL,
+            "http_method": _Test_HTTP_Method,
+            "parameters": ['{"name": "arg1", "required": false, "default": "val1", "type": "str"}'],
+            "response": _Test_HTTP_Resp,
         }
         namespace = Namespace(**namespace_args)
         arguments = deserialize.subcommand_add(namespace)
@@ -74,6 +82,11 @@ class TestDeserialize:
         assert arguments.generate_sample == _Generate_Sample
         assert arguments.print_sample == _Print_Sample
         assert arguments.sample_output_path == _Sample_File_Path
+        assert arguments.api_config_path == _Sample_File_Path
+        assert arguments.api_path == _Test_URL
+        assert arguments.http_method == _Test_HTTP_Method
+        assert arguments.parameters == [{"name": "arg1", "required": False, "default": "val1", "type": "str"}]
+        assert arguments.response == _Test_HTTP_Resp
 
     @pytest.mark.parametrize(
         (


### PR DESCRIPTION
### _Target_

* Add new command line options of subcommand **_add_**.


### _Effecting Scope_

* Provide new options for adding new API to mock.
    * ``--api-config-path``

    Set the configuration file path where it should use to get and update content or add write setting to it.

    ```console
    --api-config-path <config file path>
    ```

    * ``--api-path``

    Set the API path.

    ```console
    --api-path '/foo-home'
    ```

    * ``--http-method``

    Set the HTTP method.

    ```console
    --http-method 'GET'
    ```

    * ``--parameters``

    Set the HTTP request parameters.

    ```console
    --parameters '{"name": "arg1", "required": true}' --parameters '{"name": "arg2", "required": false}'
    ```

    * ``--response``

    Set the HTTP response.

    ```console
    --response 'OK'
    ```


### _Description_

* Add new command line options of subcommand line **_add_**.
* Implement the feature about adding new API with the new command line options.
* Add new functions operates data object **HTTP**.
* Add unit tests for new feature.
