### PR TITLE
🎉🎊🍾 [New Feature] Add new command line option for generating different response way in sample configuration.

### DIFF
--- a/pymock_api/command/options.py
+++ b/pymock_api/command/options.py
@@ -381,6 +381,15 @@ class Output(BaseSubCmdSampleOption):
     default_value: str = "sample-api.yaml"
 
 
+class DemoSampleType(BaseSubCmdSampleOption):
+    cli_option: str = "-t, --sample-config-type"
+    name: str = "sample_config_type"
+    help_description: str = "Which configuration type (the type means the response way) you want to demonstrate."
+    option_value_type: type = str
+    default_value: str = "all"
+    _options: List[str] = ["all", "response_as_str", "response_as_json", "response_with_file"]
+
+
 class APIConfigPath(BaseSubCmdAddOption):
     cli_option: str = "--api-config-path"
     name: str = "api_config_path"

--- a/pymock_api/command/process.py
+++ b/pymock_api/command/process.py
@@ -1,4 +1,5 @@
 import copy
+import sys
 from argparse import ArgumentParser, Namespace
 from typing import List, Optional, Tuple, Type
 
@@ -180,4 +181,9 @@ class SubCmdSample(BaseCommandProcessor):
         return SubCmdSampleComponent()
 
     def _parse_process(self, parser: ArgumentParser, cmd_args: Optional[List[str]] = None) -> SubcmdSampleArguments:
-        return deserialize_args.subcmd_sample(self._parse_cmd_arguments(parser, cmd_args))
+        cmd_options = self._parse_cmd_arguments(parser, cmd_args)
+        try:
+            return deserialize_args.subcmd_sample(cmd_options)
+        except KeyError:
+            print(f"❌  Invalid value of option *--sample-config-type*: {cmd_options.sample_config_type}.")
+            sys.exit(1)

--- a/pymock_api/command/sample/component.py
+++ b/pymock_api/command/sample/component.py
@@ -15,8 +15,8 @@ class SubCmdSampleComponent(BaseSubCmdComponent):
         sample_config = get_sample_by_type(args.sample_config_type)
         sample_data: str = yaml.serialize(config=sample_config)
         if args.print_sample:
-            print(f"It will write below content into file {args.sample_output_path}:")
             print(f"{sample_data}")
         if args.generate_sample:
             assert args.sample_output_path, _option_cannot_be_empty_assertion("-o, --output")
             yaml.write(path=args.sample_output_path, config=sample_data)
+            print(f"🍻  Write sample configuration into file {args.sample_output_path}.")

--- a/pymock_api/command/sample/component.py
+++ b/pymock_api/command/sample/component.py
@@ -1,5 +1,5 @@
 from ..._utils import YAML
-from ...model._sample import Sample_Config_Value
+from ...model._sample import get_sample_by_type
 from ...model.cmd_args import SubcmdSampleArguments
 from ..component import BaseSubCmdComponent
 
@@ -12,7 +12,8 @@ class SubCmdSampleComponent(BaseSubCmdComponent):
     def process(self, args: SubcmdSampleArguments) -> None:  # type: ignore[override]
         # TODO: Add logic about using mapping file operation by the file extension.
         yaml: YAML = YAML()
-        sample_data: str = yaml.serialize(config=Sample_Config_Value)
+        sample_config = get_sample_by_type(args.sample_config_type)
+        sample_data: str = yaml.serialize(config=sample_config)
         if args.print_sample:
             print(f"It will write below content into file {args.sample_output_path}:")
             print(f"{sample_data}")

--- a/pymock_api/model/_sample.py
+++ b/pymock_api/model/_sample.py
@@ -32,9 +32,9 @@ File_Content: dict = {
 
 Mocked_APIs: dict = {
     "base": {"url": "/test/v1"},
-    SampleType.RESPONSE_AS_STR: Str_Resp_API,
-    SampleType.RESPONSE_AS_JSON: Json_Resp_API,
-    SampleType.RESPONSE_WITH_FILE: File_Content_Resp_Value,
+    SampleType.RESPONSE_AS_STR.value: Str_Resp_API,
+    SampleType.RESPONSE_AS_JSON.value: Json_Resp_API,
+    SampleType.RESPONSE_WITH_FILE.value: File_Content_Resp_Value,
 }
 
 Sample_Config_Value: dict = {
@@ -61,21 +61,21 @@ class sample_config:
     @classmethod
     def response_as_str(cls) -> dict:
         return cls._config(
-            name=SampleType.RESPONSE_AS_STR,
+            name=SampleType.RESPONSE_AS_STR.value,
             response=Str_Resp_API,
         )
 
     @classmethod
     def response_as_json(cls) -> dict:
         return cls._config(
-            name=SampleType.RESPONSE_AS_JSON,
+            name=SampleType.RESPONSE_AS_JSON.value,
             response=Json_Resp_API,
         )
 
     @classmethod
     def response_with_file(cls) -> dict:
         return cls._config(
-            name=SampleType.RESPONSE_WITH_FILE,
+            name=SampleType.RESPONSE_WITH_FILE.value,
             response=File_Content_Resp_Value,
         )
 
@@ -84,7 +84,7 @@ class sample_config:
         return Sample_Config_Value
 
     @classmethod
-    def _config(cls, name: SampleType, response: dict) -> dict:
+    def _config(cls, name: str, response: dict) -> dict:
         return {
             "name": "Sample mock API",
             "description": "This is a sample config for the usage demonstration.",

--- a/pymock_api/model/_sample.py
+++ b/pymock_api/model/_sample.py
@@ -1,3 +1,5 @@
+from ..model.enums import SampleType
+
 Str_Resp_API: dict = {
     "url": "/test-str-resp",
     "http": {
@@ -30,9 +32,9 @@ File_Content: dict = {
 
 Mocked_APIs: dict = {
     "base": {"url": "/test/v1"},
-    "str_response": Str_Resp_API,
-    "json_response": Json_Resp_API,
-    "file_content_response": File_Content_Resp_Value,
+    SampleType.RESPONSE_AS_STR: Str_Resp_API,
+    SampleType.RESPONSE_AS_JSON: Json_Resp_API,
+    SampleType.RESPONSE_WITH_FILE: File_Content_Resp_Value,
 }
 
 Sample_Config_Value: dict = {
@@ -42,25 +44,38 @@ Sample_Config_Value: dict = {
 }
 
 
+def get_sample_by_type(t: SampleType) -> dict:
+    if t is SampleType.RESPONSE_AS_STR:
+        return sample_config.response_as_str()
+    elif t is SampleType.RESPONSE_AS_JSON:
+        return sample_config.response_as_json()
+    elif t is SampleType.RESPONSE_WITH_FILE:
+        return sample_config.response_with_file()
+    elif t is SampleType.ALL:
+        return sample_config.response()
+    else:
+        raise ValueError(f"It doesn't support the sample type {t}.")
+
+
 class sample_config:
     @classmethod
     def response_as_str(cls) -> dict:
         return cls._config(
-            name="str_response",
+            name=SampleType.RESPONSE_AS_STR,
             response=Str_Resp_API,
         )
 
     @classmethod
     def response_as_json(cls) -> dict:
         return cls._config(
-            name="json_response",
+            name=SampleType.RESPONSE_AS_JSON,
             response=Json_Resp_API,
         )
 
     @classmethod
     def response_with_file(cls) -> dict:
         return cls._config(
-            name="file_content_response",
+            name=SampleType.RESPONSE_WITH_FILE,
             response=File_Content_Resp_Value,
         )
 
@@ -69,7 +84,7 @@ class sample_config:
         return Sample_Config_Value
 
     @classmethod
-    def _config(cls, name: str, response: dict) -> dict:
+    def _config(cls, name: SampleType, response: dict) -> dict:
         return {
             "name": "Sample mock API",
             "description": "This is a sample config for the usage demonstration.",

--- a/pymock_api/model/cmd_args.py
+++ b/pymock_api/model/cmd_args.py
@@ -3,7 +3,7 @@ from argparse import Namespace
 from dataclasses import dataclass
 from typing import List, Optional
 
-from ..model.enums import Format
+from ..model.enums import Format, SampleType
 
 
 @dataclass(frozen=True)
@@ -65,6 +65,7 @@ class SubcmdSampleArguments(ParserArguments):
     generate_sample: bool
     print_sample: bool
     sample_output_path: str
+    sample_config_type: SampleType
 
 
 class DeserializeParsedArgs:
@@ -128,4 +129,5 @@ class DeserializeParsedArgs:
             generate_sample=args.generate_sample,
             print_sample=args.print_sample,
             sample_output_path=args.file_path,
+            sample_config_type=SampleType[str(args.sample_config_type).upper()],
         )

--- a/pymock_api/model/enums.py
+++ b/pymock_api/model/enums.py
@@ -5,3 +5,10 @@ class Format(Enum):
     TEXT: str = "text"
     YAML: str = "yaml"
     JSON: str = "json"
+
+
+class SampleType(Enum):
+    ALL: str = "response_all"
+    RESPONSE_AS_STR: str = "response_as_str"
+    RESPONSE_AS_JSON: str = "response_as_json"
+    RESPONSE_WITH_FILE: str = "response_with_file"

--- a/test/_values.py
+++ b/test/_values.py
@@ -171,3 +171,4 @@ _Test_SubCommand_Sample: str = "sample"
 _Generate_Sample: bool = True
 _Print_Sample: bool = True
 _Sample_File_Path: str = "pytest-api.yaml"
+_Sample_Data_Type: str = "all"

--- a/test/unit_test/command/process.py
+++ b/test/unit_test/command/process.py
@@ -730,6 +730,17 @@ class TestSubCmdSample(BaseCommandProcessorTestSpec):
     def _expected_argument_type(self) -> Type[SubcmdSampleArguments]:
         return SubcmdSampleArguments
 
+    def test__parse_process_with_invalid_type(self, cmd_ps: SubCmdSample):
+        cmd_arg_namespace = self._given_cmd_args_namespace()
+        cmd_arg_namespace.sample_config_type = "invalid_type"
+        parser = Mock()
+        cmd_args = Mock()
+        with patch.object(cmd_ps, "_parse_cmd_arguments", return_value=cmd_arg_namespace) as mock_parse_cmd_arguments:
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_ps._parse_process(parser, cmd_args)
+            mock_parse_cmd_arguments.assert_called_once_with(parser, cmd_args)
+            assert str(exc_info.value) == "1"
+
 
 def test_make_command_chain():
     assert len(get_all_subcommands()) == len(make_command_chain()) - _No_SubCmd_Amt - _Fake_Amt

--- a/test/unit_test/command/process.py
+++ b/test/unit_test/command/process.py
@@ -30,7 +30,7 @@ from pymock_api.model import (
     SubcmdRunArguments,
     SubcmdSampleArguments,
 )
-from pymock_api.model.enums import Format
+from pymock_api.model.enums import Format, SampleType
 from pymock_api.server import ASGIServer, Command, CommandOptions, WSGIServer
 
 from ..._values import (
@@ -40,6 +40,7 @@ from ..._values import (
     _Generate_Sample,
     _Log_Level,
     _Print_Sample,
+    _Sample_Data_Type,
     _Sample_File_Path,
     _Show_Detail_As_Format,
     _Test_App_Type,
@@ -83,13 +84,10 @@ def _given_parser_args(
     elif subcommand == "add":
         return SubcmdAddArguments(
             subparser_name=subcommand,
-            print_sample=_Print_Sample,
-            generate_sample=_Generate_Sample,
-            sample_output_path=_Sample_File_Path,
             api_config_path=_Sample_File_Path,
             api_path=_Test_URL,
             http_method=_Test_HTTP_Method,
-            parameters="",
+            parameters=[],
             response=_Test_HTTP_Resp,
         )
     elif subcommand == "check":
@@ -697,6 +695,7 @@ class TestSubCmdSample(BaseCommandProcessorTestSpec):
             print_sample=oprint,
             generate_sample=generate,
             sample_output_path=output,
+            sample_config_type=SampleType.ALL,
         )
 
         with patch("builtins.print", autospec=True, side_effect=print) as mock_print:
@@ -722,6 +721,7 @@ class TestSubCmdSample(BaseCommandProcessorTestSpec):
         args_namespace.generate_sample = _Generate_Sample
         args_namespace.print_sample = _Print_Sample
         args_namespace.file_path = _Sample_File_Path
+        args_namespace.sample_config_type = _Sample_Data_Type
         return args_namespace
 
     def _given_subcmd(self) -> Optional[str]:

--- a/test/unit_test/model/cmd_args.py
+++ b/test/unit_test/model/cmd_args.py
@@ -12,7 +12,7 @@ from pymock_api.model.cmd_args import (
     SubcmdRunArguments,
     SubcmdSampleArguments,
 )
-from pymock_api.model.enums import Format
+from pymock_api.model.enums import Format, SampleType
 
 from ..._values import (
     _Bind_Host_And_Port,
@@ -179,6 +179,7 @@ class TestDeserialize:
             "generate_sample": _Generate_Sample,
             "print_sample": _Print_Sample,
             "file_path": _Sample_File_Path,
+            "sample_config_type": SampleType.ALL,
         }
         namespace = Namespace(**namespace_args)
         arguments = deserialize.subcommand_sample(namespace)

--- a/test/unit_test/model/cmd_args.py
+++ b/test/unit_test/model/cmd_args.py
@@ -21,6 +21,7 @@ from ..._values import (
     _Generate_Sample,
     _Log_Level,
     _Print_Sample,
+    _Sample_Data_Type,
     _Sample_File_Path,
     _Show_Detail_As_Format,
     _Swagger_API_Document_URL,
@@ -179,7 +180,7 @@ class TestDeserialize:
             "generate_sample": _Generate_Sample,
             "print_sample": _Print_Sample,
             "file_path": _Sample_File_Path,
-            "sample_config_type": SampleType.ALL,
+            "sample_config_type": _Sample_Data_Type,
         }
         namespace = Namespace(**namespace_args)
         arguments = deserialize.subcommand_sample(namespace)
@@ -188,3 +189,4 @@ class TestDeserialize:
         assert arguments.generate_sample == _Generate_Sample
         assert arguments.print_sample == _Print_Sample
         assert arguments.sample_output_path == _Sample_File_Path
+        assert arguments.sample_config_type == SampleType.ALL

--- a/test/unit_test/model/sample.py
+++ b/test/unit_test/model/sample.py
@@ -14,10 +14,10 @@ def test_get_sample_by_valid_type(st: SampleType):
         assert len(sample_data["mocked_apis"].keys()) == 3 + base_config_number
         all_sample_types = list(filter(lambda t: t is not SampleType.ALL, SampleType))
         for sample_type in all_sample_types:
-            assert sample_type in sample_data["mocked_apis"].keys()
+            assert sample_type.value in sample_data["mocked_apis"].keys()
     else:
         assert len(sample_data["mocked_apis"].keys()) == 1 + base_config_number
-        assert st in sample_data["mocked_apis"].keys()
+        assert st.value in sample_data["mocked_apis"].keys()
 
 
 @pytest.mark.parametrize("invalid_st", ["invalid_type"])

--- a/test/unit_test/model/sample.py
+++ b/test/unit_test/model/sample.py
@@ -1,0 +1,27 @@
+import re
+
+import pytest
+
+from pymock_api.model._sample import get_sample_by_type
+from pymock_api.model.enums import SampleType
+
+
+@pytest.mark.parametrize("st", SampleType)
+def test_get_sample_by_valid_type(st: SampleType):
+    base_config_number: int = 1
+    sample_data = get_sample_by_type(st)
+    if st is SampleType.ALL:
+        assert len(sample_data["mocked_apis"].keys()) == 3 + base_config_number
+        all_sample_types = list(filter(lambda t: t is not SampleType.ALL, SampleType))
+        for sample_type in all_sample_types:
+            assert sample_type in sample_data["mocked_apis"].keys()
+    else:
+        assert len(sample_data["mocked_apis"].keys()) == 1 + base_config_number
+        assert st in sample_data["mocked_apis"].keys()
+
+
+@pytest.mark.parametrize("invalid_st", ["invalid_type"])
+def test_get_sample_by_invalid_type(invalid_st: SampleType):
+    with pytest.raises(ValueError) as exc_info:
+        get_sample_by_type(invalid_st)
+    assert re.search(r".{0,64}doesn't support.{0,64}" + re.escape(invalid_st), str(exc_info.value), re.IGNORECASE)


### PR DESCRIPTION
### _Target_

* Add new command line option for generating different response way in sample configuration.
* Example usage:
    ```console
    >>> mock-api sample -p -t 'response_as_json'
    It will write below content into file sample-api.yaml:
    description: This is a sample config for the usage demonstration.
    mocked_apis:
      base:
        url: /test/v1
      response_as_json:
        http:
          request:
            method: GET
            parameters:
            - param1: val1
          response:
            value: '{ "responseCode": "200", "errorMessage": "OK", "content": "This is
              sample API as JSON format value." }'
        url: /test-json-resp
    name: Sample mock API
    ```


### _Effecting Scope_

* Provide new command line option for usage.


### _Description_

* Add new command line option ``--sample-config-type``.
* Add new logic about getting different response way of sample configuration in command line processor.
