### PR TITLE
🎉🎊🍾 [New Feature] Add new sub-command line *pull* for getting and transferring the API document, e.g., Swagger to PyMock-API format configuration.

### DIFF
--- a/pymock_api/command/add/component.py
+++ b/pymock_api/command/add/component.py
@@ -41,7 +41,7 @@ class SubCmdAddComponent(BaseSubCmdComponent):
             mocked_api.url = args.api_path.replace(base.url, "") if base else args.api_path
         if args.http_method or args.parameters:
             try:
-                mocked_api.set_request(method=args.http_method, parameters=args.parameters)
+                mocked_api.set_request(method=args.http_method, parameters=args.parameters)  # type: ignore[arg-type]
             except ValueError:
                 print("❌  The data format of API parameter is incorrect.")
                 sys.exit(1)

--- a/pymock_api/command/options.py
+++ b/pymock_api/command/options.py
@@ -535,3 +535,18 @@ class GetWithHTTPMethod(BaseSubCmdGetOption):
         "This is an option for searching condition which cannot be used individually. Add "
         "condition of HTTP method to get the API info."
     )
+
+
+class Source(BaseSubCmdPullOption):
+    cli_option: str = "-s, --source"
+    name: str = "source"
+    help_description: str = "The source where keeps API details as documentation."
+
+
+class PullToConfigPath(BaseSubCmdPullOption):
+    cli_option: str = "-c, --config-path"
+    name: str = "config_path"
+    help_description: str = (
+        "The file path where program will write the deserialization result configuration of API documentation, e.g., "
+        "Swagger API documentation to it."
+    )

--- a/pymock_api/command/options.py
+++ b/pymock_api/command/options.py
@@ -543,6 +543,12 @@ class Source(BaseSubCmdPullOption):
     help_description: str = "The source where keeps API details as documentation."
 
 
+class PullBaseURL(BaseSubCmdPullOption):
+    cli_option: str = "--base-url"
+    name: str = "base_url"
+    help_description: str = "The base URL which must be the part of path all the APIs begin with."
+
+
 class PullToConfigPath(BaseSubCmdPullOption):
     cli_option: str = "-c, --config-path"
     name: str = "config_path"

--- a/pymock_api/command/options.py
+++ b/pymock_api/command/options.py
@@ -230,6 +230,7 @@ class SubCommand:
     Check: str = "check"
     Get: str = "get"
     Sample: str = "sample"
+    Pull: str = "pull"
 
 
 class BaseSubCommand(CommandOption):
@@ -278,12 +279,20 @@ class SubCommandSampleOption(BaseSubCommand):
     )
 
 
+class SubCommandPullOption(BaseSubCommand):
+    sub_parser: SubParserAttr = SubParserAttr(
+        name=SubCommand.Pull,
+        help="Pull the API details from one specific source, e.g., Swagger API documentation.",
+    )
+
+
 BaseCmdOption: type = MetaCommandOption("BaseCmdOption", (CommandOption,), {})
 BaseSubCmdRunOption: type = MetaCommandOption("BaseSubCmdRunOption", (SubCommandRunOption,), {})
 BaseSubCmdAddOption: type = MetaCommandOption("BaseSubCmdAddOption", (SubCommandAddOption,), {})
 BaseSubCmdCheckOption: type = MetaCommandOption("BaseSubCmdCheckOption", (SubCommandCheckOption,), {})
 BaseSubCmdGetOption: type = MetaCommandOption("BaseSubCmdGetOption", (SubCommandGetOption,), {})
 BaseSubCmdSampleOption: type = MetaCommandOption("BaseSubCmdSampleOption", (SubCommandSampleOption,), {})
+BaseSubCmdPullOption: type = MetaCommandOption("BaseSubCmdPullOption", (SubCommandPullOption,), {})
 
 
 class Version(BaseCmdOption):

--- a/pymock_api/command/process.py
+++ b/pymock_api/command/process.py
@@ -8,6 +8,7 @@ from ..model import (
     SubcmdAddArguments,
     SubcmdCheckArguments,
     SubcmdGetArguments,
+    SubcmdPullArguments,
     SubcmdRunArguments,
     SubcmdSampleArguments,
     deserialize_args,
@@ -17,6 +18,7 @@ from .check import SubCmdCheckComponent
 from .component import BaseSubCmdComponent, NoSubCmdComponent
 from .get import SubCmdGetComponent
 from .options import MockAPICommandParser, SubCommand
+from .pull.component import SubCmdPullComponent
 from .run import SubCmdRunComponent
 from .sample.component import SubCmdSampleComponent
 
@@ -187,3 +189,14 @@ class SubCmdSample(BaseCommandProcessor):
         except KeyError:
             print(f"❌  Invalid value of option *--sample-config-type*: {cmd_options.sample_config_type}.")
             sys.exit(1)
+
+
+class SubCmdPull(BaseCommandProcessor):
+    responsible_subcommand = SubCommand.Pull
+
+    @property
+    def _subcmd_component(self) -> SubCmdPullComponent:
+        return SubCmdPullComponent()
+
+    def _parse_process(self, parser: ArgumentParser, cmd_args: Optional[List[str]] = None) -> SubcmdPullArguments:
+        return deserialize_args.subcmd_pull(self._parse_cmd_arguments(parser, cmd_args))

--- a/pymock_api/command/pull/component.py
+++ b/pymock_api/command/pull/component.py
@@ -13,7 +13,7 @@ class SubCmdPullComponent(BaseSubCmdComponent):
     def process(self, args: SubcmdPullArguments) -> None:  # type: ignore[override]
         print(f"Try to get Swagger API documentation content at 'http://{args.source}/'.")
         swagger_api_doc = self._get_swagger_config(swagger_url=f"http://{args.source}/")
-        api_config = swagger_api_doc.to_api_config()
+        api_config = swagger_api_doc.to_api_config(base_url=args.base_url)
         print("Write the API configuration to file ...")
         self._file.write(path=args.config_path, config=api_config.serialize())
         print(f"All configuration has been writen in file '{args.config_path}'.")

--- a/pymock_api/command/pull/component.py
+++ b/pymock_api/command/pull/component.py
@@ -1,0 +1,23 @@
+from ..._utils import YAML
+from ..._utils.api_client import URLLibHTTPClient
+from ...model import SwaggerConfig, deserialize_swagger_api_config
+from ...model.cmd_args import SubcmdPullArguments
+from ..component import BaseSubCmdComponent
+
+
+class SubCmdPullComponent(BaseSubCmdComponent):
+    def __init__(self):
+        self._api_client = URLLibHTTPClient()
+        self._file = YAML()
+
+    def process(self, args: SubcmdPullArguments) -> None:  # type: ignore[override]
+        print(f"Try to get Swagger API documentation content at 'http://{args.source}/'.")
+        swagger_api_doc = self._get_swagger_config(swagger_url=f"http://{args.source}/")
+        api_config = swagger_api_doc.to_api_config()
+        print("Write the API configuration to file ...")
+        self._file.write(path=args.config_path, config=api_config.serialize())
+        print(f"All configuration has been writen in file '{args.config_path}'.")
+
+    def _get_swagger_config(self, swagger_url: str) -> SwaggerConfig:
+        swagger_api_doc: dict = self._api_client.request(method="GET", url=swagger_url)
+        return deserialize_swagger_api_config(data=swagger_api_doc)

--- a/pymock_api/model/__init__.py
+++ b/pymock_api/model/__init__.py
@@ -22,6 +22,7 @@ from .cmd_args import (
     SubcmdAddArguments,
     SubcmdCheckArguments,
     SubcmdGetArguments,
+    SubcmdPullArguments,
     SubcmdRunArguments,
     SubcmdSampleArguments,
 )
@@ -93,6 +94,19 @@ class deserialize_args:
 
         """
         return DeserializeParsedArgs.subcommand_sample(args)
+
+    @classmethod
+    def subcmd_pull(cls, args: Namespace) -> SubcmdPullArguments:
+        """Deserialize the object *argparse.Namespace* to *ParserArguments*.
+
+        Args:
+            args (Namespace): The arguments which be parsed from current command line.
+
+        Returns:
+            A *ParserArguments* type object.
+
+        """
+        return DeserializeParsedArgs.subcommand_pull(args)
 
 
 def deserialize_swagger_api_config(data: dict) -> SwaggerConfig:

--- a/pymock_api/model/cmd_args.py
+++ b/pymock_api/model/cmd_args.py
@@ -71,6 +71,7 @@ class SubcmdSampleArguments(ParserArguments):
 @dataclass(frozen=True)
 class SubcmdPullArguments(ParserArguments):
     source: str
+    base_url: str
     config_path: str
 
 
@@ -143,5 +144,6 @@ class DeserializeParsedArgs:
         return SubcmdPullArguments(
             subparser_name=args.subcommand,
             source=args.source,
+            base_url=args.base_url,
             config_path=args.config_path,
         )

--- a/pymock_api/model/cmd_args.py
+++ b/pymock_api/model/cmd_args.py
@@ -68,6 +68,12 @@ class SubcmdSampleArguments(ParserArguments):
     sample_config_type: SampleType
 
 
+@dataclass(frozen=True)
+class SubcmdPullArguments(ParserArguments):
+    source: str
+    config_path: str
+
+
 class DeserializeParsedArgs:
     """*Deserialize the object *argparse.Namespace* to *ParserArguments*"""
 
@@ -130,4 +136,12 @@ class DeserializeParsedArgs:
             print_sample=args.print_sample,
             sample_output_path=args.file_path,
             sample_config_type=SampleType[str(args.sample_config_type).upper()],
+        )
+
+    @classmethod
+    def subcommand_pull(cls, args: Namespace) -> SubcmdPullArguments:
+        return SubcmdPullArguments(
+            subparser_name=args.subcommand,
+            source=args.source,
+            config_path=args.config_path,
         )

--- a/pymock_api/model/swagger_config.py
+++ b/pymock_api/model/swagger_config.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Type
 
 from pymock_api.model.api_config import APIConfig
 from pymock_api.model.api_config import APIParameter as PyMockAPIParameter
-from pymock_api.model.api_config import MockAPI, _Config
+from pymock_api.model.api_config import BaseConfig, MockAPI, MockAPIs, _Config
 
 Self = Any
 
@@ -92,4 +92,8 @@ class SwaggerConfig(BaseSwaggerDataModel):
         return self
 
     def to_api_config(self) -> APIConfig:
-        return APIConfig()
+        api_config = APIConfig(name="", description="", apis=MockAPIs(base=BaseConfig(url=""), apis={}))
+        assert api_config.apis is not None and api_config.apis.apis == {}
+        for swagger_api in self.paths:
+            api_config.apis.apis[swagger_api.path] = swagger_api.to_api_config()
+        return api_config

--- a/pymock_api/model/swagger_config.py
+++ b/pymock_api/model/swagger_config.py
@@ -1,6 +1,6 @@
 import json
 from abc import ABCMeta, abstractmethod
-from typing import Any, Dict, List, Type
+from typing import Any, Dict, List
 
 from pymock_api.model.api_config import APIConfig
 from pymock_api.model.api_config import APIParameter as PyMockAPIParameter

--- a/pymock_api/model/swagger_config.py
+++ b/pymock_api/model/swagger_config.py
@@ -1,5 +1,9 @@
 from abc import ABCMeta, abstractmethod
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Type
+
+from pymock_api.model.api_config import APIConfig
+from pymock_api.model.api_config import APIParameter as PyMockAPIParameter
+from pymock_api.model.api_config import MockAPI, _Config
 
 Self = Any
 
@@ -20,6 +24,10 @@ class BaseSwaggerDataModel(metaclass=ABCMeta):
     def deserialize(self, data: Dict) -> Self:
         pass
 
+    @abstractmethod
+    def to_api_config(self) -> _Config:
+        pass
+
 
 class APIParameter(BaseSwaggerDataModel):
     def __init__(self):
@@ -34,6 +42,9 @@ class APIParameter(BaseSwaggerDataModel):
         self.value_type = convert_js_type(data["schema"]["type"])
         self.default = data["schema"]["default"]
         return self
+
+    def to_api_config(self) -> PyMockAPIParameter:
+        return PyMockAPIParameter()
 
 
 class API(BaseSwaggerDataModel):
@@ -51,6 +62,9 @@ class API(BaseSwaggerDataModel):
             self.response = http_info["responses"]
         return self
 
+    def to_api_config(self) -> MockAPI:
+        return MockAPI()
+
 
 class SwaggerConfig(BaseSwaggerDataModel):
     def __init__(self):
@@ -63,3 +77,6 @@ class SwaggerConfig(BaseSwaggerDataModel):
             api.path = api_path
             self.paths.append(api)
         return self
+
+    def to_api_config(self) -> APIConfig:
+        return APIConfig()

--- a/pymock_api/model/swagger_config.py
+++ b/pymock_api/model/swagger_config.py
@@ -50,7 +50,7 @@ class APIParameter(BaseSwaggerDataModel):
             required=self.required,
             value_type=self.value_type,
             default=self.default,
-            value_format="",
+            value_format=None,
         )
 
 
@@ -66,13 +66,13 @@ class API(BaseSwaggerDataModel):
             self.http_method = http_method
             self.parameters = list(map(lambda p: APIParameter().deserialize(data=p), http_info["parameters"]))
             # TODO: Process the response
-            self.response = http_info["responses"]
+            self.response = http_info["responses"]["200"]["content"]["application/json"]["schema"]
         return self
 
     def to_api_config(self) -> MockAPI:
         mock_api = MockAPI(url=self.path)
         mock_api.set_request(
-            method=self.http_method,
+            method=self.http_method.upper(),
             parameters=list(map(lambda p: p.to_api_config(), self.parameters)),
         )
         mock_api.set_response(value=json.dumps(self.response))
@@ -95,5 +95,5 @@ class SwaggerConfig(BaseSwaggerDataModel):
         api_config = APIConfig(name="", description="", apis=MockAPIs(base=BaseConfig(url=""), apis={}))
         assert api_config.apis is not None and api_config.apis.apis == {}
         for swagger_api in self.paths:
-            api_config.apis.apis[swagger_api.path] = swagger_api.to_api_config()
+            api_config.apis.apis[swagger_api.path[1:].replace("/", "_")] = swagger_api.to_api_config()
         return api_config

--- a/pymock_api/model/swagger_config.py
+++ b/pymock_api/model/swagger_config.py
@@ -1,3 +1,4 @@
+import json
 from abc import ABCMeta, abstractmethod
 from typing import Any, Dict, List, Type
 
@@ -69,7 +70,13 @@ class API(BaseSwaggerDataModel):
         return self
 
     def to_api_config(self) -> MockAPI:
-        return MockAPI()
+        mock_api = MockAPI(url=self.path)
+        mock_api.set_request(
+            method=self.http_method,
+            parameters=list(map(lambda p: p.to_api_config(), self.parameters)),
+        )
+        mock_api.set_response(value=json.dumps(self.response))
+        return mock_api
 
 
 class SwaggerConfig(BaseSwaggerDataModel):

--- a/pymock_api/model/swagger_config.py
+++ b/pymock_api/model/swagger_config.py
@@ -44,7 +44,13 @@ class APIParameter(BaseSwaggerDataModel):
         return self
 
     def to_api_config(self) -> PyMockAPIParameter:
-        return PyMockAPIParameter()
+        return PyMockAPIParameter(
+            name=self.name,
+            required=self.required,
+            value_type=self.value_type,
+            default=self.default,
+            value_format="",
+        )
 
 
 class API(BaseSwaggerDataModel):

--- a/test/_values.py
+++ b/test/_values.py
@@ -172,3 +172,7 @@ _Generate_Sample: bool = True
 _Print_Sample: bool = True
 _Sample_File_Path: str = "pytest-api.yaml"
 _Sample_Data_Type: str = "all"
+
+# Test subcommand *config* options
+_Test_SubCommand_Pull: str = "pull"
+_API_Doc_Source: str = "127.0.0.1:8080"

--- a/test/data/pull_test/config/has-base-info_test.yaml
+++ b/test/data/pull_test/config/has-base-info_test.yaml
@@ -3,7 +3,7 @@ description: ''
 mocked_apis:
   base:
     url: '/test/v1'
-  foo_home:
+  foo:
     url: '/foo'
     http:
       request:

--- a/test/data/pull_test/config/has-base-info_test.yaml
+++ b/test/data/pull_test/config/has-base-info_test.yaml
@@ -1,0 +1,28 @@
+name: ''
+description: ''
+mocked_apis:
+  base:
+    url: '/test/v1'
+  foo_home:
+    url: '/foo'
+    http:
+      request:
+        method: 'GET'
+        parameters:
+          - name: 'arg1'
+            required: false
+            type: str
+            default: 'arg1_default_value'
+            format:
+          - name: 'arg2'
+            required: false
+            type: int
+            default: 0
+            format:
+          - name: 'arg3'
+            required: false
+            type: bool
+            default: false
+            format:
+      response:
+        value: '{}'

--- a/test/data/pull_test/config/no-base-info_test.yaml
+++ b/test/data/pull_test/config/no-base-info_test.yaml
@@ -1,0 +1,27 @@
+name: ''
+description: ''
+mocked_apis:
+  base:
+  foo:
+    url: '/foo'
+    http:
+      request:
+        method: 'GET'
+        parameters:
+          - name: 'arg1'
+            required: false
+            type: str
+            default: 'arg1_default_value'
+            format:
+          - name: 'arg2'
+            required: false
+            type: int
+            default: 0
+            format:
+          - name: 'arg3'
+            required: false
+            type: bool
+            default: false
+            format:
+      response:
+        value: '{}'

--- a/test/data/pull_test/swagger/has-base-info_swagger-doc_by_python_fastapi.json
+++ b/test/data/pull_test/swagger/has-base-info_swagger-doc_by_python_fastapi.json
@@ -1,0 +1,117 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "FastAPI",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/test/v1/foo": {
+      "get": {
+        "summary": "Foo Home",
+        "operationId": "foo_home_test_v1_foo_get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "title": "Arg1",
+              "type": "string",
+              "default": "arg1_default_value"
+            },
+            "name": "arg1",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Arg2",
+              "type": "integer",
+              "default": 0
+            },
+            "name": "arg2",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Arg3",
+              "type": "boolean",
+              "default": false
+            },
+            "name": "arg3",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HTTPValidationError": {
+        "title": "HTTPValidationError",
+        "type": "object",
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            }
+          }
+        }
+      },
+      "ValidationError": {
+        "title": "ValidationError",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "loc": {
+            "title": "Location",
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            }
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/data/pull_test/swagger/no-base-info_swagger-doc_by_python_fastapi.json
+++ b/test/data/pull_test/swagger/no-base-info_swagger-doc_by_python_fastapi.json
@@ -1,0 +1,117 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "FastAPI",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/foo": {
+      "get": {
+        "summary": "Foo Home",
+        "operationId": "foo_home_foo_get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "title": "Arg1",
+              "type": "string",
+              "default": "arg1_default_value"
+            },
+            "name": "arg1",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Arg2",
+              "type": "integer",
+              "default": 0
+            },
+            "name": "arg2",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Arg3",
+              "type": "boolean",
+              "default": false
+            },
+            "name": "arg3",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HTTPValidationError": {
+        "title": "HTTPValidationError",
+        "type": "object",
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            }
+          }
+        }
+      },
+      "ValidationError": {
+        "title": "ValidationError",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "loc": {
+            "title": "Location",
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            }
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/unit_test/model/cmd_args.py
+++ b/test/unit_test/model/cmd_args.py
@@ -9,12 +9,14 @@ from pymock_api.model.cmd_args import (
     SubcmdAddArguments,
     SubcmdCheckArguments,
     SubcmdGetArguments,
+    SubcmdPullArguments,
     SubcmdRunArguments,
     SubcmdSampleArguments,
 )
 from pymock_api.model.enums import Format, SampleType
 
 from ..._values import (
+    _API_Doc_Source,
     _Bind_Host_And_Port,
     _Cmd_Arg_API_Path,
     _Cmd_Arg_HTTP_Method,
@@ -32,6 +34,7 @@ from ..._values import (
     _Test_SubCommand_Add,
     _Test_SubCommand_Check,
     _Test_SubCommand_Get,
+    _Test_SubCommand_Pull,
     _Test_SubCommand_Run,
     _Test_SubCommand_Sample,
     _Test_URL,
@@ -190,3 +193,16 @@ class TestDeserialize:
         assert arguments.print_sample == _Print_Sample
         assert arguments.sample_output_path == _Sample_File_Path
         assert arguments.sample_config_type == SampleType.ALL
+
+    def test_parser_subcommand_pull_arguments(self, deserialize: Type[DeserializeParsedArgs]):
+        namespace_args = {
+            "subcommand": _Test_SubCommand_Pull,
+            "source": _API_Doc_Source,
+            "config_path": _Test_Config,
+        }
+        namespace = Namespace(**namespace_args)
+        arguments = deserialize.subcommand_pull(namespace)
+        assert isinstance(arguments, SubcmdPullArguments)
+        assert arguments.subparser_name == _Test_SubCommand_Pull
+        assert arguments.source == _API_Doc_Source
+        assert arguments.config_path == _Test_Config

--- a/test/unit_test/model/cmd_args.py
+++ b/test/unit_test/model/cmd_args.py
@@ -17,6 +17,7 @@ from pymock_api.model.enums import Format, SampleType
 
 from ..._values import (
     _API_Doc_Source,
+    _Base_URL,
     _Bind_Host_And_Port,
     _Cmd_Arg_API_Path,
     _Cmd_Arg_HTTP_Method,
@@ -198,6 +199,7 @@ class TestDeserialize:
         namespace_args = {
             "subcommand": _Test_SubCommand_Pull,
             "source": _API_Doc_Source,
+            "base_url": _Base_URL,
             "config_path": _Test_Config,
         }
         namespace = Namespace(**namespace_args)

--- a/test/unit_test/model/init.py
+++ b/test/unit_test/model/init.py
@@ -8,6 +8,8 @@ from pymock_api.model import (
 )
 
 from ..._values import (
+    _API_Doc_Source,
+    _Base_URL,
     _Bind_Host_And_Port,
     _Generate_Sample,
     _Log_Level,
@@ -19,6 +21,7 @@ from ..._values import (
     _Test_SubCommand_Add,
     _Test_SubCommand_Check,
     _Test_SubCommand_Get,
+    _Test_SubCommand_Pull,
     _Test_SubCommand_Run,
     _Workers_Amount,
 )
@@ -75,6 +78,19 @@ def test_deserialize_subcommand_get_args(mock_parser_arguments: Mock):
     }
     namespace = Namespace(**namespace_args)
     deserialize_args.subcmd_get(namespace)
+    mock_parser_arguments.assert_called_once_with(namespace)
+
+
+@patch.object(DeserializeParsedArgs, "subcommand_pull")
+def test_deserialize_subcommand_get_args(mock_parser_arguments: Mock):
+    namespace_args = {
+        "subcommand": _Test_SubCommand_Pull,
+        "source": _API_Doc_Source,
+        "base_url": _Base_URL,
+        "config_path": _Test_Config,
+    }
+    namespace = Namespace(**namespace_args)
+    deserialize_args.subcmd_pull(namespace)
     mock_parser_arguments.assert_called_once_with(namespace)
 
 

--- a/test/unit_test/model/swagger_config.py
+++ b/test/unit_test/model/swagger_config.py
@@ -172,10 +172,30 @@ class TestAPI(_SwaggerDataModelTestSuite):
                 assert api_param.default == one_swagger_api_param["schema"]["default"]
 
     def _given_props(self, data_model: API) -> None:
-        pass
+        params = APIParameter()
+        params.name = "arg1"
+        params.required = False
+        params.value_type = "string"
+        params.default = "default_value_pytest"
+
+        data_model.path = "/test/v1/foo-home"
+        data_model.http_method = "POST"
+        data_model.parameters = [params]
+        data_model.response = {}
 
     def _verify_api_config_model(self, under_test: MockAPI, data_from: API) -> None:
-        pass
+        assert under_test.url == data_from.path
+        assert under_test.http.request.method == data_from.http_method
+        assert len(under_test.http.request.parameters) == len(data_from.parameters)
+        for p in under_test.http.request.parameters:
+            api_param_in_data_from = list(filter(lambda _p: _p.name == p.name, data_from.parameters))
+            assert len(api_param_in_data_from) == 1
+            param_data_from = api_param_in_data_from[0]
+            assert p.name == param_data_from.name
+            assert p.required == param_data_from.required
+            assert p.value_type == param_data_from.value_type
+            assert p.default == param_data_from.default
+            assert p.value_format == ""
 
 
 class TestSwaggerConfig(_SwaggerDataModelTestSuite):

--- a/test/unit_test/model/swagger_config.py
+++ b/test/unit_test/model/swagger_config.py
@@ -83,7 +83,7 @@ class _SwaggerDataModelTestSuite(metaclass=ABCMeta):
     def test_to_api_config(self, data_model: BaseSwaggerDataModel):
         self._given_props(data_model)
         new_data_model = data_model.to_api_config()
-        self._verify_api_config_model(new_data_model)
+        self._verify_api_config_model(under_test=new_data_model, data_from=data_model)
 
     @abstractmethod
     def _initial(self, data: BaseSwaggerDataModel) -> None:
@@ -98,7 +98,7 @@ class _SwaggerDataModelTestSuite(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def _verify_api_config_model(self, new_data_model: _Config) -> None:
+    def _verify_api_config_model(self, under_test: _Config, data_from: BaseSwaggerDataModel) -> None:
         pass
 
 
@@ -126,7 +126,7 @@ class TestAPIParameters(_SwaggerDataModelTestSuite):
     def _given_props(self, data_model: APIParameter) -> None:
         pass
 
-    def _verify_api_config_model(self, new_data_model: PyMockAPIParameter) -> None:
+    def _verify_api_config_model(self, under_test: PyMockAPIParameter, data_from: APIParameter) -> None:
         pass
 
 
@@ -167,7 +167,7 @@ class TestAPI(_SwaggerDataModelTestSuite):
     def _given_props(self, data_model: API) -> None:
         pass
 
-    def _verify_api_config_model(self, new_data_model: MockAPI) -> None:
+    def _verify_api_config_model(self, under_test: MockAPI, data_from: API) -> None:
         pass
 
 
@@ -206,5 +206,5 @@ class TestSwaggerConfig(_SwaggerDataModelTestSuite):
     def _given_props(self, data_model: SwaggerConfig) -> None:
         pass
 
-    def _verify_api_config_model(self, new_data_model: APIConfig) -> None:
+    def _verify_api_config_model(self, under_test: APIConfig, data_from: SwaggerConfig) -> None:
         pass

--- a/test/unit_test/model/swagger_config.py
+++ b/test/unit_test/model/swagger_config.py
@@ -7,6 +7,9 @@ from typing import List, Optional
 
 import pytest
 
+from pymock_api.model.api_config import APIConfig
+from pymock_api.model.api_config import APIParameter as PyMockAPIParameter
+from pymock_api.model.api_config import MockAPI, _Config
 from pymock_api.model.swagger_config import (
     API,
     APIParameter,
@@ -77,12 +80,25 @@ class _SwaggerDataModelTestSuite(metaclass=ABCMeta):
         assert deserialized_data
         self._verify_result(data=deserialized_data, og_data=swagger_api_doc_data)
 
+    def test_to_api_config(self, data_model: BaseSwaggerDataModel):
+        self._given_props(data_model)
+        new_data_model = data_model.to_api_config()
+        self._verify_api_config_model(new_data_model)
+
     @abstractmethod
     def _initial(self, data: BaseSwaggerDataModel) -> None:
         pass
 
     @abstractmethod
     def _verify_result(self, data: BaseSwaggerDataModel, og_data: dict) -> None:
+        pass
+
+    @abstractmethod
+    def _given_props(self, data_model: BaseSwaggerDataModel) -> None:
+        pass
+
+    @abstractmethod
+    def _verify_api_config_model(self, new_data_model: _Config) -> None:
         pass
 
 
@@ -106,6 +122,12 @@ class TestAPIParameters(_SwaggerDataModelTestSuite):
         assert data.required == og_data["required"]
         assert data.value_type == convert_js_type(og_data["schema"]["type"])
         assert data.default == og_data["schema"]["default"]
+
+    def _given_props(self, data_model: APIParameter) -> None:
+        pass
+
+    def _verify_api_config_model(self, new_data_model: PyMockAPIParameter) -> None:
+        pass
 
 
 class TestAPI(_SwaggerDataModelTestSuite):
@@ -142,6 +164,12 @@ class TestAPI(_SwaggerDataModelTestSuite):
                 assert api_param.value_type == convert_js_type(one_swagger_api_param["schema"]["type"])
                 assert api_param.default == one_swagger_api_param["schema"]["default"]
 
+    def _given_props(self, data_model: API) -> None:
+        pass
+
+    def _verify_api_config_model(self, new_data_model: MockAPI) -> None:
+        pass
+
 
 class TestSwaggerConfig(_SwaggerDataModelTestSuite):
     @pytest.fixture(scope="function")
@@ -174,3 +202,9 @@ class TestSwaggerConfig(_SwaggerDataModelTestSuite):
                 assert api_param.required == one_swagger_api_param["required"]
                 assert api_param.value_type == convert_js_type(one_swagger_api_param["schema"]["type"])
                 assert api_param.default == one_swagger_api_param["schema"]["default"]
+
+    def _given_props(self, data_model: SwaggerConfig) -> None:
+        pass
+
+    def _verify_api_config_model(self, new_data_model: APIConfig) -> None:
+        pass

--- a/test/unit_test/model/swagger_config.py
+++ b/test/unit_test/model/swagger_config.py
@@ -124,10 +124,17 @@ class TestAPIParameters(_SwaggerDataModelTestSuite):
         assert data.default == og_data["schema"]["default"]
 
     def _given_props(self, data_model: APIParameter) -> None:
-        pass
+        data_model.name = "arg1"
+        data_model.required = False
+        data_model.value_type = "string"
+        data_model.default = "default_value_pytest"
 
     def _verify_api_config_model(self, under_test: PyMockAPIParameter, data_from: APIParameter) -> None:
-        pass
+        assert under_test.name == data_from.name
+        assert under_test.required == data_from.required
+        assert under_test.value_type == data_from.value_type
+        assert under_test.default == data_from.default
+        assert under_test.value_format == ""
 
 
 class TestAPI(_SwaggerDataModelTestSuite):

--- a/test/unit_test/model/swagger_config.py
+++ b/test/unit_test/model/swagger_config.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 import pytest
 
 from pymock_api.model.swagger_config import (
+    APIParameter,
     BaseSwaggerDataModel,
     SwaggerConfig,
     convert_js_type,
@@ -82,6 +83,28 @@ class _SwaggerDataModelTestSuite(metaclass=ABCMeta):
     @abstractmethod
     def _verify_result(self, data: BaseSwaggerDataModel, og_data: dict) -> None:
         pass
+
+
+class TestAPIParameters(_SwaggerDataModelTestSuite):
+    @pytest.fixture(scope="function")
+    def data_model(self) -> APIParameter:
+        return APIParameter()
+
+    @pytest.mark.parametrize("swagger_api_doc_data", SWAGGER_API_PARAMETERS_JSON)
+    def test_deserialize(self, swagger_api_doc_data: dict, data_model: BaseSwaggerDataModel):
+        super().test_deserialize(swagger_api_doc_data, data_model)
+
+    def _initial(self, data: APIParameter) -> None:
+        data.name = ""
+        data.required = False
+        data.value_type = ""
+        data.default = None
+
+    def _verify_result(self, data: APIParameter, og_data: dict) -> None:
+        assert data is not None
+        assert data.required == og_data["required"]
+        assert data.value_type == convert_js_type(og_data["schema"]["type"])
+        assert data.default == og_data["schema"]["default"]
 
 
 class TestSwaggerConfig(_SwaggerDataModelTestSuite):

--- a/test/unit_test/model/swagger_config.py
+++ b/test/unit_test/model/swagger_config.py
@@ -134,7 +134,7 @@ class TestAPIParameters(_SwaggerDataModelTestSuite):
         assert under_test.required == data_from.required
         assert under_test.value_type == data_from.value_type
         assert under_test.default == data_from.default
-        assert under_test.value_format == ""
+        assert under_test.value_format is None
 
 
 class TestAPI(_SwaggerDataModelTestSuite):
@@ -195,7 +195,7 @@ class TestAPI(_SwaggerDataModelTestSuite):
             assert p.required == param_data_from.required
             assert p.value_type == param_data_from.value_type
             assert p.default == param_data_from.default
-            assert p.value_format == ""
+            assert p.value_format is None
 
 
 class TestSwaggerConfig(_SwaggerDataModelTestSuite):
@@ -248,7 +248,7 @@ class TestSwaggerConfig(_SwaggerDataModelTestSuite):
     def _verify_api_config_model(self, under_test: APIConfig, data_from: SwaggerConfig) -> None:
         assert len(under_test.apis.apis.keys()) == len(data_from.paths)
         for api_path, api_details in under_test.apis.apis.items():
-            expect_apis = list(filter(lambda a: api_path == a.path, data_from.paths))
+            expect_apis = list(filter(lambda a: api_path == a.path[1:].replace("/", "_"), data_from.paths))
             assert expect_apis
             expect_api = expect_apis[0]
 


### PR DESCRIPTION
### _Target_

* Add new sub-command line **_pull_** for getting and transferring the API document, e.g., Swagger to PyMock-API format configuration.
* Usage example:
    ```console
    >>> mock-api pull -h
    usage: mock-api pull [-h] [-s SOURCE] [--base-url BASE_URL] [-c CONFIG_PATH]
    
    options:
      -h, --help            show this help message and exit
      -s SOURCE, --source SOURCE
                            The source where keeps API details as documentation.
      --base-url BASE_URL   The base URL which must be the part of path all the APIs begin with.
      -c CONFIG_PATH, --config-path CONFIG_PATH
                            The file path where program will write the deserialization result configuration of API documentation, e.g., Swagger API documentation to it.
    ```


### _Effecting Scope_

* Provide new sub-command line **_pull_** without any breaking changes.


### _Description_

* Add new sub-command line **_pull_** and its command line options.
* Fix some test fails.
