### PR TITLE
🎉🎊🍾 [New Feature] Support new keys *tag* for classify APIs and *items* for the element details of iterable API parameter.

### DIFF
--- a/pymock_api/model/api_config.py
+++ b/pymock_api/model/api_config.py
@@ -161,7 +161,7 @@ class APIParameter(_Config):
 
     def _convert_items(self):
         if False in list(map(lambda i: isinstance(i, (dict, IteratorItem)), self.items)):
-            raise TypeError("")
+            raise TypeError("The data type of key *items* must be dict or IteratorItem.")
         self.items = [
             IteratorItem(name=i.get("name", ""), value_type=i.get("type", None), required=i.get("required", True))
             if isinstance(i, dict)

--- a/pymock_api/model/api_config.py
+++ b/pymock_api/model/api_config.py
@@ -105,6 +105,35 @@ class BaseConfig(_Config):
 
 
 @dataclass(eq=False)
+class IteratorItem(_Config):
+    name: str = field(default_factory=str)
+    required: Optional[bool] = None
+    value_type: Optional[str] = None  # A type value as string
+
+    def _compare(self, other: "IteratorItem") -> bool:
+        return self.name == other.name and self.required == other.required and self.value_type == other.value_type
+
+    def serialize(self, data: Optional["IteratorItem"] = None) -> Optional[Dict[str, Any]]:
+        name: str = self._get_prop(data, prop="name")
+        required: bool = self._get_prop(data, prop="required")
+        value_type: type = self._get_prop(data, prop="value_type")
+        if not (name and value_type) or (required is None):
+            return None
+        return {
+            "name": name,
+            "required": required,
+            "type": value_type,
+        }
+
+    @_Config._ensure_process_with_not_empty_value
+    def deserialize(self, data: Dict[str, Any]) -> Optional["IteratorItem"]:
+        self.name = data.get("name", None)
+        self.required = data.get("required", None)
+        self.value_type = data.get("type", None)
+        return self
+
+
+@dataclass(eq=False)
 class APIParameter(_Config):
     name: str = field(default_factory=str)
     required: Optional[bool] = None

--- a/pymock_api/model/api_config.py
+++ b/pymock_api/model/api_config.py
@@ -119,11 +119,13 @@ class IteratorItem(_Config):
         value_type: type = self._get_prop(data, prop="value_type")
         if not value_type or (required is None):
             return None
-        return {
-            "name": name,
+        serialized_data = {
             "required": required,
             "type": value_type,
         }
+        if name:
+            serialized_data["name"] = name
+        return serialized_data
 
     @_Config._ensure_process_with_not_empty_value
     def deserialize(self, data: Dict[str, Any]) -> Optional["IteratorItem"]:

--- a/pymock_api/model/api_config.py
+++ b/pymock_api/model/api_config.py
@@ -2,7 +2,6 @@
 
 content ...
 """
-import sys
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Union

--- a/pymock_api/model/api_config.py
+++ b/pymock_api/model/api_config.py
@@ -140,6 +140,7 @@ class APIParameter(_Config):
     default: Optional[Any] = None
     value_type: Optional[str] = None  # A type value as string
     value_format: Optional[str] = None
+    items: Optional[List[IteratorItem]] = None
 
     def _compare(self, other: "APIParameter") -> bool:
         # TODO: Let it could automatically scan what properties it has and compare all of their value.
@@ -149,6 +150,7 @@ class APIParameter(_Config):
             and self.default == other.default
             and self.value_type == other.value_type
             and self.value_format == other.value_format
+            and self.items == other.items
         )
 
     def serialize(self, data: Optional["APIParameter"] = None) -> Optional[Dict[str, Any]]:
@@ -159,13 +161,16 @@ class APIParameter(_Config):
         value_format: str = self._get_prop(data, prop="value_format")
         if not (name and value_type) or (required is None):
             return None
-        return {
+        serialized_data = {
             "name": name,
             "required": required,
             "default": default,
             "type": value_type,
             "format": value_format,
         }
+        if self.items:
+            serialized_data["items"] = [item.serialize() for item in self.items]
+        return serialized_data
 
     @_Config._ensure_process_with_not_empty_value
     def deserialize(self, data: Dict[str, Any]) -> Optional["APIParameter"]:
@@ -174,6 +179,8 @@ class APIParameter(_Config):
         self.default = data.get("default", None)
         self.value_type = data.get("type", None)
         self.value_format = data.get("format", None)
+        items = [IteratorItem().deserialize(item) for item in data.get("items", [])]
+        self.items = items if items else None
         return self
 
 

--- a/pymock_api/model/api_config.py
+++ b/pymock_api/model/api_config.py
@@ -157,16 +157,17 @@ class APIParameter(_Config):
 
     def __post_init__(self) -> None:
         if self.items is not None:
-            if False in list(map(lambda i: isinstance(i, (dict, IteratorItem)), self.items)):
-                raise TypeError("")
-            self.items = [
-                IteratorItem(
-                    name=i.get("name", ""), value_type=i.get("value_type", "str"), required=i.get("required", True)
-                )
-                if isinstance(i, dict)
-                else i
-                for i in self.items
-            ]
+            self._convert_items()
+
+    def _convert_items(self):
+        if False in list(map(lambda i: isinstance(i, (dict, IteratorItem)), self.items)):
+            raise TypeError("")
+        self.items = [
+            IteratorItem(name=i.get("name", ""), value_type=i.get("type", None), required=i.get("required", True))
+            if isinstance(i, dict)
+            else i
+            for i in self.items
+        ]
 
     def serialize(self, data: Optional["APIParameter"] = None) -> Optional[Dict[str, Any]]:
         name: str = self._get_prop(data, prop="name")

--- a/pymock_api/model/api_config.py
+++ b/pymock_api/model/api_config.py
@@ -345,10 +345,12 @@ class MockAPI(_Config):
 
     _url: Optional[str]
     _http: Optional[HTTP]
+    _tag: str = ""
 
-    def __init__(self, url: Optional[str] = None, http: Optional[HTTP] = None):
+    def __init__(self, url: Optional[str] = None, http: Optional[HTTP] = None, tag: str = ""):
         self._url = url
         self._http = http
+        self._tag = tag
 
     def _compare(self, other: "MockAPI") -> bool:
         return self.url == other.url and self.http == other.http
@@ -377,14 +379,26 @@ class MockAPI(_Config):
         else:
             self._http = None
 
+    @property
+    def tag(self) -> str:
+        return self._tag
+
+    @tag.setter
+    def tag(self, tag: str) -> None:
+        if not isinstance(tag, str):
+            raise TypeError("Setter *MockAPI.tag* only accepts str type value.")
+        self._tag = tag
+
     def serialize(self, data: Optional["MockAPI"] = None) -> Optional[Dict[str, Any]]:
         url = (data.url if data else None) or self._url
         http = (data.http if data else None) or self.http
         if not (url and http):
             return None
+        tag = (data.tag if data else None) or self.tag
         return {
             "url": url,
             "http": http.serialize(data=http),
+            "tag": tag,
         }
 
     @_Config._ensure_process_with_not_empty_value
@@ -421,6 +435,7 @@ class MockAPI(_Config):
         self.url = data.get("url", None)
         http_info = data.get("http", None)
         self.http = HTTP().deserialize(data=http_info) if http_info else None
+        self.tag = data.get("tag", "")
         return self
 
     def set_request(self, method: str = "GET", parameters: Optional[List[Union[dict, APIParameter]]] = None) -> None:

--- a/pymock_api/model/swagger_config.py
+++ b/pymock_api/model/swagger_config.py
@@ -22,6 +22,13 @@ def convert_js_type(t: str) -> str:
         raise TypeError(f"Currently, it cannot parse JS type '{t}'.")
 
 
+# TODO: Should clean the parsing process
+def ensure_type_is_python_type(t: str) -> str:
+    if t in ["string", "integer", "number", "boolean", "array"]:
+        return convert_js_type(t)
+    return t
+
+
 ComponentDefinition: Dict[str, dict] = {}
 
 
@@ -144,6 +151,9 @@ class API(Transferable):
             handled_parameters = self._process_has_ref_parameters(params_data[0])
         else:
             # TODO: Parsing the data type of key *items* should be valid type of Python realm
+            for param in params_data:
+                if param.get("items", None) is not None:
+                    param["items"]["type"] = ensure_type_is_python_type(param["items"]["type"])
             handled_parameters = params_data
         print(f"[DEBUG in swagger_config.API._process_api_params] handled_parameters: {handled_parameters}")
         return list(map(lambda p: APIParameter().deserialize(data=p), handled_parameters))

--- a/pymock_api/model/swagger_config.py
+++ b/pymock_api/model/swagger_config.py
@@ -160,7 +160,7 @@ class API(Transferable):
         return parameters
 
     def to_api_config(self, base_url: str = "") -> MockAPI:  # type: ignore[override]
-        mock_api = MockAPI(url=self.path.replace(base_url, ""))
+        mock_api = MockAPI(url=self.path.replace(base_url, ""), tag=self.tags[0] if self.tags else "")
         mock_api.set_request(
             method=self.http_method.upper(),
             parameters=list(map(lambda p: p.to_api_config(), self.parameters)),

--- a/pymock_api/model/swagger_config.py
+++ b/pymock_api/model/swagger_config.py
@@ -93,7 +93,7 @@ class APIParameter(Transferable):
     def has_schema(self, data: Dict) -> bool:
         return data.get("schema", None) is not None
 
-    def has_ref_in_schema(self, data: Dict) -> str:
+    def has_ref(self, data: Dict) -> str:
         if self.has_schema(data):
             has_schema_ref = data["schema"].get("$ref", None) is not None
             return "schema" if has_schema_ref else ""
@@ -107,7 +107,7 @@ class APIParameter(Transferable):
                 return data
             raise ValueError(f"This data '{data}' doesn't have key 'schema'.")
 
-        if self.has_ref_in_schema(data):
+        if self.has_ref(data):
             raise NotImplementedError
         else:
             return {
@@ -135,7 +135,7 @@ class API(Transferable):
 
     def _process_api_params(self, params_data: List[dict]) -> List["APIParameter"]:
         config_api_parameters = APIParameter()
-        has_ref_in_schema_param = list(filter(lambda p: config_api_parameters.has_ref_in_schema(p) != "", params_data))
+        has_ref_in_schema_param = list(filter(lambda p: config_api_parameters.has_ref(p) != "", params_data))
         print(f"[DEBUG in swagger_config.API._process_api_params] params_data: {params_data}")
         if has_ref_in_schema_param:
             assert len(params_data) == 1
@@ -154,7 +154,7 @@ class API(Transferable):
             items = param_props.get("items", None)
             print(f"[DEBUG in swagger_config.API._process_has_ref_parameters] before items: {items}")
             items_props = []
-            if items and config_api_parameters.has_ref_in_schema(items) != "":
+            if items and config_api_parameters.has_ref(items):
                 items = self._get_schema_ref(items)
                 print(f"[DEBUG in swagger_config.API._process_has_ref_parameters] after items: {items}")
                 # Sample data:
@@ -197,7 +197,7 @@ class API(Transferable):
                 return _get_schema(component_def_data[paths[i]], paths, i + 1)
 
         config_api_parameters = APIParameter()
-        has_ref = config_api_parameters.has_ref_in_schema(data)
+        has_ref = config_api_parameters.has_ref(data)
         if not has_ref:
             raise ValueError("This parameter has no ref in schema.")
         schema_path = (data["schema"]["$ref"] if has_ref == "schema" else data["$ref"]).replace("#/", "").split("/")[1:]

--- a/pymock_api/model/swagger_config.py
+++ b/pymock_api/model/swagger_config.py
@@ -69,6 +69,7 @@ class APIParameter(Transferable):
     def deserialize(self, data: Dict) -> "APIParameter":
         print(f"[DEBUG in swagger_config.APIParameter.deserialize] data: {data}")
         handled_data = self.parse_schema(data)
+        print(f"[DEBUG in swagger_config.APIParameter.deserialize] handled_data: {handled_data}")
         self.name = handled_data["name"]
         self.required = handled_data["required"]
         self.value_type = convert_js_type(handled_data["type"])
@@ -138,9 +139,11 @@ class API(Transferable):
         has_ref_in_schema_param = list(filter(lambda p: config_api_parameters.has_ref(p) != "", params_data))
         print(f"[DEBUG in swagger_config.API._process_api_params] params_data: {params_data}")
         if has_ref_in_schema_param:
+            # TODO: Ensure the value maps this condition is really only one
             assert len(params_data) == 1
             handled_parameters = self._process_has_ref_parameters(params_data[0])
         else:
+            # TODO: Parsing the data type of key *items* should be valid type of Python realm
             handled_parameters = params_data
         print(f"[DEBUG in swagger_config.API._process_api_params] handled_parameters: {handled_parameters}")
         return list(map(lambda p: APIParameter().deserialize(data=p), handled_parameters))
@@ -172,7 +175,7 @@ class API(Transferable):
                         {
                             "name": item_name,
                             "required": item_name in items["required"],
-                            "value_type": convert_js_type(item_prop["type"]),
+                            "type": convert_js_type(item_prop["type"]),
                             "default": item_prop.get("default", None),
                         }
                     )

--- a/test/_values.py
+++ b/test/_values.py
@@ -122,13 +122,15 @@ _Test_Config_Value: dict = {
     "mocked_apis": _Mocked_APIs,
 }
 
+_Test_Tag: str = "pytest-mocked-api"
+
 
 # Sample configuration content
 class _TestConfig:
     Request: dict = {"method": "GET", "parameters": [_Test_API_Parameter]}
     Response: Dict[str, str] = {"value": _Test_HTTP_Resp}
     Http: dict = {"request": Request, "response": Response}
-    Mock_API: dict = {"url": _Test_URL, "http": Http}
+    Mock_API: dict = {"url": _Test_URL, "http": Http, "tag": _Test_Tag}
     Base: dict = {"url": _Base_URL}
     Mock_APIs: dict = {"base": Base, "test_config": Mock_API}
     API_Config: dict = {

--- a/test/_values.py
+++ b/test/_values.py
@@ -43,13 +43,14 @@ _Test_Iterable_Parameter_Item_Value: dict = {
     "required": True,
     "type": "str",
 }
+_Test_Iterable_Parameter_Items: List[dict] = [_Test_Iterable_Parameter_Item_Name, _Test_Iterable_Parameter_Item_Value]
 _Test_Iterable_Parameter: dict = {
     "name": "iterable_param",
     "required": True,
     "default": None,
     "type": "list",
     "format": None,
-    "items": [_Test_Iterable_Parameter_Item_Name, _Test_Iterable_Parameter_Item_Value],
+    "items": _Test_Iterable_Parameter_Items,
 }
 
 # Sample API parameters

--- a/test/_values.py
+++ b/test/_values.py
@@ -32,6 +32,26 @@ _Mock_API_HTTP: dict = {
     "response": Mock,
 }
 
+# Sample item of iterator
+_Test_Iterable_Parameter_Item_Name: dict = {
+    "name": "name",
+    "required": True,
+    "type": "str",
+}
+_Test_Iterable_Parameter_Item_Value: dict = {
+    "name": "value",
+    "required": True,
+    "type": "str",
+}
+_Test_Iterable_Parameter: dict = {
+    "name": "iterable_param",
+    "required": True,
+    "default": None,
+    "type": "list",
+    "format": None,
+    "items": [_Test_Iterable_Parameter_Item_Name, _Test_Iterable_Parameter_Item_Value],
+}
+
 # Sample API parameters
 _Test_API_Parameter: dict = {
     "name": "param1",

--- a/test/data/pull_test/config/has-base-info_and_tags_test.yaml
+++ b/test/data/pull_test/config/has-base-info_and_tags_test.yaml
@@ -11,13 +11,13 @@ mocked_apis:
         parameters:
           - name: 'date'
             required: true
-            type: str
             default:
+            type: str
             format:
           - name: 'fooType'
             required: true
-            type: str
             default:
+            type: str
             format:
       response:
         value: '{}'
@@ -30,16 +30,16 @@ mocked_apis:
         parameters:
           - name: 'balances'
             required: true
-            type: list
-            items:
-              - name: "id"
-                required: true
-                type: int
-              - name: "value"
-                required: true
-                type: int
             default:
+            type: list
             format:
+            items:
+              - required: true
+                type: int
+                name: "value"
+              - required: true
+                type: int
+                name: "id"
       response:
         value: '{}'
     tag: 'foo'
@@ -51,21 +51,21 @@ mocked_apis:
         parameters:
           - name: 'arg1'
             required: false
-            type: list
             default:
+            type: list
             format:
             items:
               - required: true
                 type: str
           - name: 'arg2'
             required: false
-            type: str
             default:
+            type: str
             format:
           - name: 'datetime'
             required: false
-            type: str
             default:
+            type: str
             format:
       response:
         value: '{}'

--- a/test/data/pull_test/config/has-base-info_and_tags_test.yaml
+++ b/test/data/pull_test/config/has-base-info_and_tags_test.yaml
@@ -31,14 +31,13 @@ mocked_apis:
           - name: 'balances'
             required: true
             type: list
-# # New feature
-#            items:
-#              - name: "id"
-#                required: true
-#                type: int
-#              - name: "value"
-#                required: true
-#                type: int
+            items:
+              - name: "id"
+                required: true
+                type: int
+              - name: "value"
+                required: true
+                type: int
             default:
             format:
       response:
@@ -55,6 +54,9 @@ mocked_apis:
             type: list
             default:
             format:
+            items:
+              - required: true
+                type: str
           - name: 'arg2'
             required: false
             type: str

--- a/test/data/pull_test/config/has-base-info_and_tags_test.yaml
+++ b/test/data/pull_test/config/has-base-info_and_tags_test.yaml
@@ -21,6 +21,7 @@ mocked_apis:
             format:
       response:
         value: '{}'
+    tag: 'foo'
   put_foo:
     url: '/foo'
     http:
@@ -42,6 +43,7 @@ mocked_apis:
             format:
       response:
         value: '{}'
+    tag: 'foo'
   get_foo-boo_export:
     url: '/foo-boo/export'
     http:
@@ -65,3 +67,4 @@ mocked_apis:
             format:
       response:
         value: '{}'
+    tag: 'foo-boo'

--- a/test/data/pull_test/config/has-base-info_test.yaml
+++ b/test/data/pull_test/config/has-base-info_test.yaml
@@ -26,3 +26,4 @@ mocked_apis:
             format:
       response:
         value: '{}'
+    tag: ''

--- a/test/data/pull_test/config/no-base-info_test.yaml
+++ b/test/data/pull_test/config/no-base-info_test.yaml
@@ -25,3 +25,4 @@ mocked_apis:
             format:
       response:
         value: '{}'
+    tag: ''

--- a/test/data/pull_test/swagger/has-base-info_and_tags_test.json
+++ b/test/data/pull_test/swagger/has-base-info_and_tags_test.json
@@ -284,11 +284,11 @@
         "UpdateOneFooDto": {
             "type": "object",
             "required": [
-                "values",
+                "value",
                 "id"
             ],
             "properties": {
-                "values": {
+                "value": {
                     "type": "number",
                     "example": 23434,
                     "description": "value"

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -786,6 +786,20 @@ class TestAPIParameter(ConfigTestSpec):
             assert i.required == criteria["required"]
             assert i.value_type == criteria["type"]
 
+    def test_converting_at_prop_items_with_invalid_value(self):
+        with pytest.raises(TypeError) as exc_info:
+            APIParameter(
+                name="name",
+                required=False,
+                value_type="str",
+                items=[1, [], ()],
+            )
+        assert re.search(
+            r".{0,64}data type.{0,64}key \*items\*.{0,64}be dict or IteratorItem.{0,64}",
+            str(exc_info.value),
+            re.IGNORECASE,
+        )
+
 
 class TestIteratorItem(ConfigTestSpec):
     @pytest.fixture(scope="function")

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -452,6 +452,12 @@ class TestMockAPI(ConfigTestSpec):
         mock_deserialize.assert_not_called()
         assert re.search(r"Setter .{1,32} only accepts .{1,32} type object.", str(exc_info.value), re.IGNORECASE)
 
+    @pytest.mark.parametrize("invalid_value", [[], (), 123])
+    def test_prop_tag_with_invalid_obj(self, invalid_value: object, sut_with_nothing: MockAPI):
+        with pytest.raises(TypeError) as exc_info:
+            sut_with_nothing.tag = invalid_value
+        assert re.search("only accepts str type value", str(exc_info.value), re.IGNORECASE)
+
     def _expected_serialize_value(self) -> dict:
         return _TestConfig.Mock_API
 

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -27,6 +27,7 @@ from ..._values import (
     _Test_API_Parameter,
     _Test_Config,
     _Test_HTTP_Resp,
+    _Test_Tag,
     _Test_URL,
     _TestConfig,
 )
@@ -84,7 +85,7 @@ class MockModel:
 
     @property
     def mock_api(self) -> Dict[str, MockAPI]:
-        return {"test_config": MockAPI(url=_Test_URL, http=self.http)}
+        return {"test_config": MockAPI(url=_Test_URL, http=self.http, tag=_Test_Tag)}
 
     @property
     def http(self) -> HTTP:
@@ -409,7 +410,7 @@ class TestBaseConfig(ConfigTestSpec):
 class TestMockAPI(ConfigTestSpec):
     @pytest.fixture(scope="function")
     def sut(self) -> MockAPI:
-        return MockAPI(url=_Test_URL, http=self._Mock_Model.http)
+        return MockAPI(url=_Test_URL, http=self._Mock_Model.http, tag=_Test_Tag)
 
     @pytest.fixture(scope="function")
     def sut_with_nothing(self) -> MockAPI:
@@ -460,6 +461,7 @@ class TestMockAPI(ConfigTestSpec):
         assert obj.http.request.method == _TestConfig.Request.get("method", None)
         assert obj.http.request.parameters == [self._Mock_Model.api_parameter]
         assert obj.http.response.value == _TestConfig.Response.get("value", None)
+        assert obj.tag == _Test_Tag
 
     @pytest.mark.parametrize(
         ("formatter", "format_object"),
@@ -496,6 +498,7 @@ class TestMockAPI(ConfigTestSpec):
         assert sut_with_nothing.http.request.parameters == [
             APIParameter(name="arg1", required=False, default="val1", value_type="str")
         ]
+        assert sut_with_nothing.tag == ""
 
     @pytest.mark.parametrize(
         "api_params",
@@ -539,6 +542,7 @@ class TestMockAPI(ConfigTestSpec):
                 assert p.default == (
                     expect_param.default if isinstance(expect_param, APIParameter) else expect_param["default"]
                 )
+        assert sut_with_nothing.tag == ""
 
     @pytest.mark.parametrize(
         "params",
@@ -566,6 +570,7 @@ class TestMockAPI(ConfigTestSpec):
         assert sut_with_nothing.http
         assert sut_with_nothing.http.response
         assert sut_with_nothing.http.response.value == ut_value
+        assert sut_with_nothing.tag == ""
 
 
 class TestHTTP(ConfigTestSpec):

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -30,6 +30,7 @@ from ..._values import (
     _Test_HTTP_Resp,
     _Test_Iterable_Parameter,
     _Test_Iterable_Parameter_Item_Name,
+    _Test_Iterable_Parameter_Item_Value,
     _Test_Iterable_Parameter_Items,
     _Test_Tag,
     _Test_URL,
@@ -758,6 +759,32 @@ class TestAPIParameter(ConfigTestSpec):
         assert sut_with_nothing.value_format == _Test_Iterable_Parameter["format"]
         assert len(sut_with_nothing.items) == len(_Test_Iterable_Parameter_Items)
         assert [item.serialize() for item in sut_with_nothing.items] == _Test_Iterable_Parameter["items"]
+
+    @pytest.mark.parametrize("items_value", [_Test_Iterable_Parameter])
+    def test_converting_at_prop_items_with_valid_value(self, items_value: dict):
+        under_test = APIParameter(
+            name=items_value["name"],
+            required=items_value["required"],
+            default=items_value["default"],
+            value_type=items_value["type"],
+            value_format=items_value["format"],
+            items=items_value["items"],
+        )
+        assert isinstance(under_test.items, list)
+        assert False not in list(map(lambda i: isinstance(i, IteratorItem), under_test.items))
+        for i in under_test.items:
+            assert i.name in [
+                _Test_Iterable_Parameter_Item_Name["name"],
+                _Test_Iterable_Parameter_Item_Value["name"],
+            ], _assertion_msg
+            if i.name == _Test_Iterable_Parameter_Item_Name["name"]:
+                criteria = _Test_Iterable_Parameter_Item_Name
+            elif i.name == _Test_Iterable_Parameter_Item_Value["name"]:
+                criteria = _Test_Iterable_Parameter_Item_Value
+            else:
+                raise ValueError("")
+            assert i.required == criteria["required"]
+            assert i.value_type == criteria["type"]
 
 
 class TestIteratorItem(ConfigTestSpec):

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -14,6 +14,7 @@ from pymock_api.model.api_config import (
     BaseConfig,
     HTTPRequest,
     HTTPResponse,
+    IteratorItem,
     MockAPI,
     MockAPIs,
     _Config,
@@ -27,6 +28,7 @@ from ..._values import (
     _Test_API_Parameter,
     _Test_Config,
     _Test_HTTP_Resp,
+    _Test_Iterable_Parameter_Item_Name,
     _Test_Tag,
     _Test_URL,
     _TestConfig,
@@ -737,6 +739,34 @@ class TestAPIParameter(ConfigTestSpec):
         assert obj.default == _Test_API_Parameter["default"]
         assert obj.value_type == _Test_API_Parameter["type"]
         assert obj.value_format == _Test_API_Parameter["format"]
+
+
+class TestIteratorItem(ConfigTestSpec):
+    @pytest.fixture(scope="function")
+    def sut(self) -> IteratorItem:
+        return IteratorItem(
+            name=_Test_Iterable_Parameter_Item_Name["name"],
+            required=_Test_Iterable_Parameter_Item_Name["required"],
+            value_type=_Test_Iterable_Parameter_Item_Name["type"],
+        )
+
+    @pytest.fixture(scope="function")
+    def sut_with_nothing(self) -> IteratorItem:
+        return IteratorItem()
+
+    def test_value_attributes(self, sut: IteratorItem):
+        assert sut.name == _Test_Iterable_Parameter_Item_Name["name"], _assertion_msg
+        assert sut.required is _Test_Iterable_Parameter_Item_Name["required"], _assertion_msg
+        assert sut.value_type == _Test_Iterable_Parameter_Item_Name["type"], _assertion_msg
+
+    def _expected_serialize_value(self) -> Any:
+        return _Test_Iterable_Parameter_Item_Name
+
+    def _expected_deserialize_value(self, obj: IteratorItem) -> None:
+        assert isinstance(obj, IteratorItem)
+        assert obj.name == _Test_Iterable_Parameter_Item_Name["name"]
+        assert obj.required is _Test_Iterable_Parameter_Item_Name["required"]
+        assert obj.value_type == _Test_Iterable_Parameter_Item_Name["type"]
 
 
 class TestHTTPResponse(ConfigTestSpec):

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -28,7 +28,9 @@ from ..._values import (
     _Test_API_Parameter,
     _Test_Config,
     _Test_HTTP_Resp,
+    _Test_Iterable_Parameter,
     _Test_Iterable_Parameter_Item_Name,
+    _Test_Iterable_Parameter_Items,
     _Test_Tag,
     _Test_URL,
     _TestConfig,
@@ -728,6 +730,7 @@ class TestAPIParameter(ConfigTestSpec):
         assert sut.default == _Test_API_Parameter["default"], _assertion_msg
         assert sut.value_type == _Test_API_Parameter["type"], _assertion_msg
         assert sut.value_format == _Test_API_Parameter["format"], _assertion_msg
+        assert sut.items is None, _assertion_msg
 
     def _expected_serialize_value(self) -> dict:
         return _Test_API_Parameter
@@ -739,6 +742,22 @@ class TestAPIParameter(ConfigTestSpec):
         assert obj.default == _Test_API_Parameter["default"]
         assert obj.value_type == _Test_API_Parameter["type"]
         assert obj.value_format == _Test_API_Parameter["format"]
+        assert obj.items is None
+
+    def test_serialize_api_parameter_with_iterable_items(self, sut_with_nothing: APIParameter):
+        sut_with_nothing.deserialize(_Test_Iterable_Parameter)
+        serialized_data = sut_with_nothing.serialize()
+        assert serialized_data == _Test_Iterable_Parameter
+
+    def test_deserialize_api_parameter_with_iterable_items(self, sut_with_nothing: APIParameter):
+        sut_with_nothing.deserialize(_Test_Iterable_Parameter)
+        assert sut_with_nothing.name == _Test_Iterable_Parameter["name"]
+        assert sut_with_nothing.required == _Test_Iterable_Parameter["required"]
+        assert sut_with_nothing.default == _Test_Iterable_Parameter["default"]
+        assert sut_with_nothing.value_type == _Test_Iterable_Parameter["type"]
+        assert sut_with_nothing.value_format == _Test_Iterable_Parameter["format"]
+        assert len(sut_with_nothing.items) == len(_Test_Iterable_Parameter_Items)
+        assert [item.serialize() for item in sut_with_nothing.items] == _Test_Iterable_Parameter["items"]
 
 
 class TestIteratorItem(ConfigTestSpec):

--- a/test/unit_test/model/swagger_config.py
+++ b/test/unit_test/model/swagger_config.py
@@ -207,6 +207,7 @@ class TestAPI(_SwaggerDataModelTestSuite):
         data_model.http_method = "POST"
         data_model.parameters = [params]
         data_model.response = {}
+        data_model.tags = ["first tag", "second tag"]
 
     def _verify_api_config_model(self, under_test: MockAPI, data_from: API) -> None:
         assert under_test.url == data_from.path
@@ -221,6 +222,7 @@ class TestAPI(_SwaggerDataModelTestSuite):
             assert p.value_type == param_data_from.value_type
             assert p.default == param_data_from.default
             assert p.value_format is None
+        assert under_test.tag == data_from.tags[0]
 
     @pytest.mark.parametrize(
         ("swagger_api_doc_data", "entire_swagger_config"), SWAGGER_API_PARAMETERS_LIST_JSON_FOR_API


### PR DESCRIPTION
### _Target_

* Support new keys **_tag_** for classify APIs and **_items_** for the element details of iterable API parameter.
* Example configuration:
    ```yaml
    mocked_apis:
      base:
        url: '/api/v1/test'
      put_foo:
        url: '/foo'
        http:
          request:
            method: 'PUT'
            parameters:
              - name: 'balances'
                required: true
                default:
                type: list
                format:
                items:
                  - required: true
                    type: int
                    name: "value"
                  - required: true
                    type: int
                    name: "id"
          response:
            value: '{}'
        tag: 'foo'
    ```


### _Effecting Scope_

* Provide new feature without any breaking changes.


### _Description_

* Add new dataclass object **IteratorItem** for the key **_items_** about iterable API parameter details.
* Add new attribute **tag** for classify APIs.
* Support parsing the reference configuration.
* Add more detail checking and criteria in tests for efficiency troubleshooting.
