### PR TITLE
🎉🎊🍾 [New Feature] Support configure HTTP response with different strategy as API response.

### DIFF
--- a/pymock_api/command/add/component.py
+++ b/pymock_api/command/add/component.py
@@ -5,6 +5,7 @@ from ..._utils import YAML
 from ...model import generate_empty_config, load_config
 from ...model.api_config import APIConfig, MockAPI
 from ...model.cmd_args import SubcmdAddArguments
+from ...model.enums import ResponseStrategy
 from ..component import BaseSubCmdComponent
 
 
@@ -45,6 +46,10 @@ class SubCmdAddComponent(BaseSubCmdComponent):
             except ValueError:
                 print("❌  The data format of API parameter is incorrect.")
                 sys.exit(1)
-        mocked_api.set_response(strategy=args.response_strategy, value=args.response)
+        if args.response_strategy is ResponseStrategy.OBJECT:
+            # TODO: Set the HTTP response data model if strategy is *object* type
+            mocked_api.set_response(strategy=args.response_strategy, iterable_value=[])
+        else:
+            mocked_api.set_response(strategy=args.response_strategy, value=args.response)
         api_config.apis.apis[args.api_path] = mocked_api
         return api_config

--- a/pymock_api/command/add/component.py
+++ b/pymock_api/command/add/component.py
@@ -5,7 +5,6 @@ from ..._utils import YAML
 from ...model import generate_empty_config, load_config
 from ...model.api_config import APIConfig, MockAPI
 from ...model.cmd_args import SubcmdAddArguments
-from ...model.enums import ResponseStrategy
 from ..component import BaseSubCmdComponent
 
 
@@ -46,7 +45,6 @@ class SubCmdAddComponent(BaseSubCmdComponent):
             except ValueError:
                 print("❌  The data format of API parameter is incorrect.")
                 sys.exit(1)
-        # TODO: Add one more command line option about HTTP response strategy
-        mocked_api.set_response(strategy=ResponseStrategy.STRING, value=args.response)
+        mocked_api.set_response(strategy=args.response_strategy, value=args.response)
         api_config.apis.apis[args.api_path] = mocked_api
         return api_config

--- a/pymock_api/command/add/component.py
+++ b/pymock_api/command/add/component.py
@@ -50,6 +50,7 @@ class SubCmdAddComponent(BaseSubCmdComponent):
             # TODO: Set the HTTP response data model if strategy is *object* type
             mocked_api.set_response(strategy=args.response_strategy, iterable_value=[])
         else:
-            mocked_api.set_response(strategy=args.response_strategy, value=args.response)
+            assert isinstance(args.response_value[0], str), "The data type must be *str*."
+            mocked_api.set_response(strategy=args.response_strategy, value=args.response_value[0])
         api_config.apis.apis[args.api_path] = mocked_api
         return api_config

--- a/pymock_api/command/add/component.py
+++ b/pymock_api/command/add/component.py
@@ -5,6 +5,7 @@ from ..._utils import YAML
 from ...model import generate_empty_config, load_config
 from ...model.api_config import APIConfig, MockAPI
 from ...model.cmd_args import SubcmdAddArguments
+from ...model.enums import ResponseStrategy
 from ..component import BaseSubCmdComponent
 
 
@@ -45,7 +46,7 @@ class SubCmdAddComponent(BaseSubCmdComponent):
             except ValueError:
                 print("❌  The data format of API parameter is incorrect.")
                 sys.exit(1)
-        if args.response:
-            mocked_api.set_response(value=args.response)
+        # TODO: Add one more command line option about HTTP response strategy
+        mocked_api.set_response(strategy=ResponseStrategy.STRING, value=args.response)
         api_config.apis.apis[args.api_path] = mocked_api
         return api_config

--- a/pymock_api/command/add/component.py
+++ b/pymock_api/command/add/component.py
@@ -47,10 +47,13 @@ class SubCmdAddComponent(BaseSubCmdComponent):
                 print("❌  The data format of API parameter is incorrect.")
                 sys.exit(1)
         if args.response_strategy is ResponseStrategy.OBJECT:
-            # TODO: Set the HTTP response data model if strategy is *object* type
-            mocked_api.set_response(strategy=args.response_strategy, iterable_value=[])
+            mocked_api.set_response(strategy=args.response_strategy, iterable_value=args.response_value)
         else:
-            assert isinstance(args.response_value[0], str), "The data type must be *str*."
-            mocked_api.set_response(strategy=args.response_strategy, value=args.response_value[0])
+            if args.response_value and not isinstance(args.response_value[0], str):
+                print("❌  The data type of command line option *--response-value* must be *str*.")
+                sys.exit(1)
+            mocked_api.set_response(
+                strategy=args.response_strategy, value=args.response_value[0] if args.response_value else None  # type: ignore[arg-type]
+            )
         api_config.apis.apis[args.api_path] = mocked_api
         return api_config

--- a/pymock_api/command/check/component.py
+++ b/pymock_api/command/check/component.py
@@ -14,6 +14,7 @@ from ...model import (
 )
 from ...model.api_config import APIConfig
 from ...model.api_config import APIParameter as MockedAPIParameter
+from ...model.enums import ResponseStrategy
 from ...model.swagger_config import API as SwaggerAPI
 from ...model.swagger_config import APIParameter as SwaggerAPIParameter
 from ..component import BaseSubCmdComponent
@@ -161,9 +162,19 @@ class ValidityChecking(_BaseChecking):
                 continue
 
             assert one_api_config.http.response
+            http_response = one_api_config.http.response
+            if http_response.strategy is ResponseStrategy.STRING:
+                under_check_value = http_response.value
+            elif http_response.strategy is ResponseStrategy.FILE:
+                under_check_value = http_response.path
+            elif http_response.strategy is ResponseStrategy.OBJECT:
+                # TODO: Implement checking properties
+                under_check_value = http_response.properties  # type: ignore[assignment]
+            else:
+                raise TypeError
             self._setting_should_not_be_none(
                 config_key=f"mocked_apis.{one_api_name}.http.response.value",
-                config_value=one_api_config.http.response.value,
+                config_value=under_check_value,
                 valid_callback=self._chk_response_value_validity,
             )
         return api_config

--- a/pymock_api/command/check/component.py
+++ b/pymock_api/command/check/component.py
@@ -2,7 +2,6 @@ import json
 import pathlib
 import re
 import sys
-import traceback
 from abc import ABCMeta, abstractmethod
 from typing import Any, Callable, Optional
 

--- a/pymock_api/command/options.py
+++ b/pymock_api/command/options.py
@@ -436,6 +436,7 @@ class AddResponseStrategy(BaseSubCmdAddOption):
     name: str = "response_strategy"
     help_description: str = "Set HTTP response strategy of one specific API."
     option_value_type: type = str
+    _options: List[str] = ["string", "file", "object"]
 
 
 class AddResponse(BaseSubCmdAddOption):

--- a/pymock_api/command/options.py
+++ b/pymock_api/command/options.py
@@ -431,6 +431,13 @@ class AddParameters(BaseSubCmdAddOption):
     default_value: str = ""
 
 
+class AddResponseStrategy(BaseSubCmdAddOption):
+    cli_option: str = "--response-strategy"
+    name: str = "response_strategy"
+    help_description: str = "Set HTTP response strategy of one specific API."
+    option_value_type: type = str
+
+
 class AddResponse(BaseSubCmdAddOption):
     cli_option: str = "--response"
     name: str = "response"

--- a/pymock_api/command/options.py
+++ b/pymock_api/command/options.py
@@ -439,9 +439,10 @@ class AddResponseStrategy(BaseSubCmdAddOption):
 
 
 class AddResponse(BaseSubCmdAddOption):
-    cli_option: str = "--response"
-    name: str = "response"
+    cli_option: str = "--response-value"
+    name: str = "response_value"
     help_description: str = "Set HTTP response value of one specific API."
+    action: str = "append"
     option_value_type: type = str
     default_value: str = "OK."
 

--- a/pymock_api/model/api_config.py
+++ b/pymock_api/model/api_config.py
@@ -371,7 +371,7 @@ class HTTPResponse(_Config):
         strategy: ResponseStrategy = self.strategy or ResponseStrategy.to_enum(self._get_prop(data, prop="strategy"))
         if strategy is ResponseStrategy.STRING:
             value: str = self._get_prop(data, prop="value")
-            if not value:
+            if not strategy or not value:
                 return None
             return {
                 "strategy": strategy.value,
@@ -379,7 +379,7 @@ class HTTPResponse(_Config):
             }
         elif strategy is ResponseStrategy.FILE:
             path: str = self._get_prop(data, prop="path")
-            if not path:
+            if not strategy or not path:
                 return None
             return {
                 "strategy": strategy.value,
@@ -388,7 +388,7 @@ class HTTPResponse(_Config):
         elif strategy is ResponseStrategy.OBJECT:
             all_properties = (data or self).properties if (data and data.properties) or self.properties else None
             properties = [prop.serialize() for prop in (all_properties or [])]
-            if not properties:
+            if not strategy or not properties:
                 return None
             return {
                 "strategy": strategy.value,

--- a/pymock_api/model/api_config.py
+++ b/pymock_api/model/api_config.py
@@ -356,15 +356,15 @@ class HTTPResponse(_Config):
         if self.strategy is not None:
             self._convert_strategy()
         if self.properties is not None:
-            self._convert_items()
+            self._convert_properties()
 
     def _convert_strategy(self) -> None:
         if isinstance(self.strategy, str):
             self.strategy = ResponseStrategy.to_enum(self.strategy)
 
-    def _convert_items(self):
+    def _convert_properties(self):
         if False in list(map(lambda i: isinstance(i, (dict, ResponseProperty)), self.properties)):
-            raise TypeError("The data type of key *items* must be dict or IteratorItem.")
+            raise TypeError("The data type of key *properties* must be dict or ResponseProperty.")
         self.properties = [ResponseProperty().deserialize(i) if isinstance(i, dict) else i for i in self.properties]
 
     def serialize(self, data: Optional["HTTPResponse"] = None) -> Optional[Dict[str, Any]]:

--- a/pymock_api/model/api_config.py
+++ b/pymock_api/model/api_config.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from .._utils.file_opt import JSON, YAML, _BaseFileOperation
-from ..model.enums import Format
+from ..model.enums import Format, ResponseStrategy
 
 # The truly semantically is more near like following:
 #
@@ -260,21 +260,146 @@ class HTTPRequest(_Config):
 
 
 @dataclass(eq=False)
+class ResponseProperty(_Config):
+    name: str = field(default_factory=str)
+    required: Optional[bool] = None
+    value_type: Optional[str] = None  # A type value as string
+    value_format: Optional[str] = None
+    items: Optional[List[IteratorItem]] = None
+
+    def _compare(self, other: "ResponseProperty") -> bool:
+        return (
+            self.name == other.name
+            and self.required == other.required
+            and self.value_type == other.value_type
+            and self.value_format == other.value_format
+            and self.items == other.items
+        )
+
+    def __post_init__(self) -> None:
+        if self.items is not None:
+            self._convert_items()
+
+    def _convert_items(self):
+        if False in list(map(lambda i: isinstance(i, (dict, IteratorItem)), self.items)):
+            raise TypeError("The data type of key *items* must be dict or IteratorItem.")
+        self.items = [
+            IteratorItem(name=i.get("name", ""), value_type=i.get("type", None), required=i.get("required", True))
+            if isinstance(i, dict)
+            else i
+            for i in self.items
+        ]
+
+    def serialize(self, data: Optional["ResponseProperty"] = None) -> Optional[Dict[str, Any]]:
+        name: str = self._get_prop(data, prop="name")
+        required: bool = self._get_prop(data, prop="required")
+        value_type: type = self._get_prop(data, prop="value_type")
+        value_format: str = self._get_prop(data, prop="value_format")
+        if not (name and value_type) or (required is None):
+            return None
+        serialized_data = {
+            "name": name,
+            "required": required,
+            "type": value_type,
+            "format": value_format,
+        }
+        if self.items:
+            print(f"[DEBUG in api_config.ResponseProperty.serialize] self.items: {self.items}")
+            serialized_data["items"] = [item.serialize() for item in self.items]
+        return serialized_data
+
+    @_Config._ensure_process_with_not_empty_value
+    def deserialize(self, data: Dict[str, Any]) -> Optional["ResponseProperty"]:
+        self.name = data.get("name", None)
+        self.required = data.get("required", None)
+        self.value_type = data.get("type", None)
+        self.value_format = data.get("format", None)
+        items = [IteratorItem().deserialize(item) for item in data.get("items", [])]
+        self.items = items if items else None
+        return self
+
+
+@dataclass(eq=False)
 class HTTPResponse(_Config):
     """*The **http.response** section in **mocked_apis.<api>***"""
 
+    strategy: ResponseStrategy = ResponseStrategy.STRING
+    """
+    Strategy:
+    * string: Return the value as string data directly.
+    * file: Return the data which be recorded in the file path as response.
+    * object: Return the response which be composed as object by some properties.
+    """
+
+    # Strategy: string
     value: str = field(default_factory=str)
 
+    # Strategy: file
+    path: str = field(default_factory=str)
+
+    # Strategy: object
+    properties: List[ResponseProperty] = field(default_factory=list)
+
     def _compare(self, other: "HTTPResponse") -> bool:
-        return self.value == other.value
+        if self.strategy is not other.strategy:
+            raise TypeError("Different HTTP response strategy cannot compare with each other.")
+        if ResponseStrategy.to_enum(self.strategy) is ResponseStrategy.STRING:
+            return self.value == other.value
+        elif ResponseStrategy.to_enum(self.strategy) is ResponseStrategy.FILE:
+            return self.path == other.path
+        elif ResponseStrategy.to_enum(self.strategy) is ResponseStrategy.OBJECT:
+            return self.properties == other.properties
+        else:
+            raise NotImplementedError
+
+    def __post_init__(self) -> None:
+        if self.strategy is not None:
+            self._convert_strategy()
+        if self.properties is not None:
+            self._convert_items()
+
+    def _convert_strategy(self) -> None:
+        if isinstance(self.strategy, str):
+            self.strategy = ResponseStrategy.to_enum(self.strategy)
+
+    def _convert_items(self):
+        if False in list(map(lambda i: isinstance(i, (dict, IteratorItem)), self.properties)):
+            raise TypeError("The data type of key *items* must be dict or IteratorItem.")
+        self.properties = [
+            IteratorItem(name=i.get("name", ""), value_type=i.get("type", None), required=i.get("required", True))
+            if isinstance(i, dict)
+            else i
+            for i in self.properties
+        ]
 
     def serialize(self, data: Optional["HTTPResponse"] = None) -> Optional[Dict[str, Any]]:
-        value: str = self._get_prop(data, prop="value")
-        if not value:
-            return None
-        return {
-            "value": value,
-        }
+        if self.strategy is ResponseStrategy.STRING:
+            value: str = self._get_prop(data, prop="value")
+            if not value:
+                return None
+            return {
+                "strategy": self.strategy.value,
+                "value": value,
+            }
+        elif self.strategy is ResponseStrategy.FILE:
+            path: str = self._get_prop(data, prop="path")
+            if not path:
+                return None
+            return {
+                "strategy": self.strategy.value,
+                "path": path,
+            }
+        elif self.strategy is ResponseStrategy.OBJECT:
+            all_properties = (data or self).properties if (data and data.properties) or self.properties else None
+            properties = [prop.serialize() for prop in (all_properties or [])]
+            if not properties:
+                return None
+            return {
+                "strategy": self.strategy.value,
+                "properties": properties,
+            }
+        else:
+            raise NotImplementedError
 
     @_Config._ensure_process_with_not_empty_value
     def deserialize(self, data: Dict[str, Any]) -> Optional["HTTPResponse"]:
@@ -298,7 +423,18 @@ class HTTPResponse(_Config):
             A **HTTPResponse** type object.
 
         """
-        self.value = data.get("value", None)
+        self.strategy = ResponseStrategy.to_enum(data.get("strategy", None))
+        if not self.strategy:
+            raise ValueError("Schema key *strategy* cannot be empty.")
+        if self.strategy is ResponseStrategy.STRING:
+            self.value = data.get("value", None)
+        elif self.strategy is ResponseStrategy.FILE:
+            self.path = data.get("path", None)
+        elif self.strategy is ResponseStrategy.OBJECT:
+            properties = [ResponseProperty().deserialize(prop) for prop in data.get("properties", [])]
+            self.properties = properties if properties else None  # type: ignore[assignment]
+        else:
+            raise NotImplementedError
         return self
 
 
@@ -518,12 +654,13 @@ class MockAPI(_Config):
                 if parameters:
                     self.http.request.parameters = params
 
-    def set_response(self, value: str = "") -> None:
+    def set_response(self, strategy: ResponseStrategy = ResponseStrategy.STRING, value: str = "") -> None:
+        # TODO: Add more argument for different HTTP response strategy
         if not self.http:
-            self.http = HTTP(request=HTTPRequest(), response=HTTPResponse(value=value))
+            self.http = HTTP(request=HTTPRequest(), response=HTTPResponse(strategy=strategy, value=value))
         else:
             if not self.http.response:
-                self.http.response = HTTPResponse(value=value)
+                self.http.response = HTTPResponse(strategy=strategy, value=value)
             else:
                 if value:
                     self.http.response.value = value

--- a/pymock_api/model/api_config.py
+++ b/pymock_api/model/api_config.py
@@ -368,29 +368,30 @@ class HTTPResponse(_Config):
         self.properties = [ResponseProperty().deserialize(i) if isinstance(i, dict) else i for i in self.properties]
 
     def serialize(self, data: Optional["HTTPResponse"] = None) -> Optional[Dict[str, Any]]:
-        if self.strategy is ResponseStrategy.STRING:
+        strategy: ResponseStrategy = self.strategy or ResponseStrategy.to_enum(self._get_prop(data, prop="strategy"))
+        if strategy is ResponseStrategy.STRING:
             value: str = self._get_prop(data, prop="value")
             if not value:
                 return None
             return {
-                "strategy": self.strategy.value,
+                "strategy": strategy.value,
                 "value": value,
             }
-        elif self.strategy is ResponseStrategy.FILE:
+        elif strategy is ResponseStrategy.FILE:
             path: str = self._get_prop(data, prop="path")
             if not path:
                 return None
             return {
-                "strategy": self.strategy.value,
+                "strategy": strategy.value,
                 "path": path,
             }
-        elif self.strategy is ResponseStrategy.OBJECT:
+        elif strategy is ResponseStrategy.OBJECT:
             all_properties = (data or self).properties if (data and data.properties) or self.properties else None
             properties = [prop.serialize() for prop in (all_properties or [])]
             if not properties:
                 return None
             return {
-                "strategy": self.strategy.value,
+                "strategy": strategy.value,
                 "properties": properties,
             }
         else:

--- a/pymock_api/model/cmd_args.py
+++ b/pymock_api/model/cmd_args.py
@@ -3,7 +3,7 @@ from argparse import Namespace
 from dataclasses import dataclass
 from typing import List, Optional
 
-from ..model.enums import Format, SampleType
+from ..model.enums import Format, ResponseStrategy, SampleType
 
 
 @dataclass(frozen=True)
@@ -28,6 +28,7 @@ class SubcmdAddArguments(ParserArguments):
     api_path: str
     http_method: str
     parameters: List[dict]
+    response_strategy: ResponseStrategy
     response: str
 
     def api_info_is_complete(self) -> bool:
@@ -99,6 +100,7 @@ class DeserializeParsedArgs:
             api_path=args.api_path,
             http_method=args.http_method,
             parameters=args.parameters,
+            response_strategy=ResponseStrategy.to_enum(args.response_strategy),
             response=args.response,
         )
 

--- a/pymock_api/model/enums.py
+++ b/pymock_api/model/enums.py
@@ -21,13 +21,6 @@ class ResponseStrategy(Enum):
     OBJECT: str = "object"
 
     @staticmethod
-    def to_str(v: Union[str, "ResponseStrategy"]) -> str:
-        if isinstance(v, str):
-            return v
-        else:
-            return v.name
-
-    @staticmethod
     def to_enum(v: Union[str, "ResponseStrategy"]) -> "ResponseStrategy":
         if isinstance(v, str):
             return ResponseStrategy(v.lower())

--- a/pymock_api/model/enums.py
+++ b/pymock_api/model/enums.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Union
 
 
 class Format(Enum):
@@ -12,3 +13,23 @@ class SampleType(Enum):
     RESPONSE_AS_STR: str = "response_as_str"
     RESPONSE_AS_JSON: str = "response_as_json"
     RESPONSE_WITH_FILE: str = "response_with_file"
+
+
+class ResponseStrategy(Enum):
+    STRING: str = "string"
+    FILE: str = "file"
+    OBJECT: str = "object"
+
+    @staticmethod
+    def to_str(v: Union[str, "ResponseStrategy"]) -> str:
+        if isinstance(v, str):
+            return v
+        else:
+            return v.name
+
+    @staticmethod
+    def to_enum(v: Union[str, "ResponseStrategy"]) -> "ResponseStrategy":
+        if isinstance(v, str):
+            return ResponseStrategy(v.lower())
+        else:
+            return v

--- a/pymock_api/model/swagger_config.py
+++ b/pymock_api/model/swagger_config.py
@@ -327,42 +327,43 @@ class API(Transferable):
                         "format": None,
                         "items": None,
                     }
-            if locate(v_type) == list:
-                single_response = _YamlSchema.get_schema_ref(property_value["items"])
-                item = {}
-                single_response_properties = single_response.get("properties", None)
-                print(f"[DEBUG in src] single_response_properties: {single_response_properties}")
-                if single_response_properties:
-                    for item_k, item_v in single_response["properties"].items():
-                        print(f"[DEBUG in src] item_v: {item_v}")
-                        print(f"[DEBUG in src] _YamlSchema.has_ref(item_v): {_YamlSchema.has_ref(item_v)}")
-                        item_type = convert_js_type(item_v["type"])
-                        if locate(item_type) is str:
-                            # lowercase_letters = string.ascii_lowercase
-                            # random_value = "".join([random.choice(lowercase_letters) for _ in range(5)])
-                            random_value = "random string value"
-                        elif locate(item_type) is int:
-                            # random_value = int(
-                            #     "".join([random.choice([f"{i}" for i in range(10)]) for _ in range(5)]))
-                            random_value = "random integer value"
-                        else:
-                            raise NotImplementedError
-                        item[item_k] = random_value
-                k_value = [item]  # type: ignore[assignment]
-            elif locate(v_type) == str:
-                # lowercase_letters = string.ascii_lowercase
-                # k_value = "".join([random.choice(lowercase_letters) for _ in range(5)])
-                k_value = "random string value"
-            elif locate(v_type) == int:
-                # k_value = int("".join([random.choice([f"{i}" for i in range(10)]) for _ in range(5)]))
-                k_value = "random integer value"
-            elif locate(v_type) == bool:
-                k_value = "random boolean value"
-            elif v_type is "file":
-                # TODO: Handle the file download feature
-                k_value = "random file output stream"
             else:
-                raise NotImplementedError
+                if locate(v_type) == list:
+                    single_response = _YamlSchema.get_schema_ref(property_value["items"])
+                    item = {}
+                    single_response_properties = single_response.get("properties", None)
+                    print(f"[DEBUG in src] single_response_properties: {single_response_properties}")
+                    if single_response_properties:
+                        for item_k, item_v in single_response["properties"].items():
+                            print(f"[DEBUG in src] item_v: {item_v}")
+                            print(f"[DEBUG in src] _YamlSchema.has_ref(item_v): {_YamlSchema.has_ref(item_v)}")
+                            item_type = convert_js_type(item_v["type"])
+                            if locate(item_type) is str:
+                                # lowercase_letters = string.ascii_lowercase
+                                # random_value = "".join([random.choice(lowercase_letters) for _ in range(5)])
+                                random_value = "random string value"
+                            elif locate(item_type) is int:
+                                # random_value = int(
+                                #     "".join([random.choice([f"{i}" for i in range(10)]) for _ in range(5)]))
+                                random_value = "random integer value"
+                            else:
+                                raise NotImplementedError
+                            item[item_k] = random_value
+                    k_value = [item]  # type: ignore[assignment]
+                elif locate(v_type) == str:
+                    # lowercase_letters = string.ascii_lowercase
+                    # k_value = "".join([random.choice(lowercase_letters) for _ in range(5)])
+                    k_value = "random string value"
+                elif locate(v_type) == int:
+                    # k_value = int("".join([random.choice([f"{i}" for i in range(10)]) for _ in range(5)]))
+                    k_value = "random integer value"
+                elif locate(v_type) == bool:
+                    k_value = "random boolean value"
+                elif v_type is "file":
+                    # TODO: Handle the file download feature
+                    k_value = "random file output stream"
+                else:
+                    raise NotImplementedError
         return k_value
 
     def to_api_config(self, base_url: str = "") -> MockAPI:  # type: ignore[override]

--- a/pymock_api/model/swagger_config.py
+++ b/pymock_api/model/swagger_config.py
@@ -165,10 +165,10 @@ class API(Transferable):
         self.process_response_strategy: ResponseStrategy = ResponseStrategy.OBJECT
 
     def deserialize(self, data: Dict) -> "API":
-        self.parameters = self._process_api_params(data["parameters"])
         # FIXME: Does it have better way to set the HTTP response strategy?
         if not self.process_response_strategy:
             raise ValueError("Please set the strategy how it should process HTTP response.")
+        self.parameters = self._process_api_params(data["parameters"])
         self.response = self._process_response(data, self.process_response_strategy)
         self.tags = data.get("tags", [])
         return self

--- a/pymock_api/model/swagger_config.py
+++ b/pymock_api/model/swagger_config.py
@@ -3,11 +3,12 @@ import random
 import string
 from abc import ABCMeta, abstractmethod
 from pydoc import locate
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from pymock_api.model.api_config import APIConfig
 from pymock_api.model.api_config import APIParameter as PyMockAPIParameter
 from pymock_api.model.api_config import BaseConfig, MockAPI, MockAPIs, _Config
+from pymock_api.model.enums import ResponseStrategy
 
 Self = Any
 
@@ -163,7 +164,8 @@ class API(Transferable):
 
     def deserialize(self, data: Dict) -> "API":
         self.parameters = self._process_api_params(data["parameters"])
-        self.response = self._process_response(data)
+        # TODO: How to set the HTTP response strategy?
+        self.response = self._process_response(data, data.get("strategy", ResponseStrategy.OBJECT))
         self.tags = data.get("tags", [])
         return self
 
@@ -226,9 +228,18 @@ class API(Transferable):
             )
         return parameters
 
-    def _process_response(self, data: dict) -> dict:
+    def _process_response(self, data: dict, strategy: ResponseStrategy) -> dict:
         status_200_response = data.get("responses", {}).get("200", {})
-        response_data = {}
+        if strategy is ResponseStrategy.OBJECT:
+            response_data = {
+                "strategy": strategy,
+                "data": [],
+            }
+        else:
+            response_data = {
+                "strategy": strategy,
+                "data": {},
+            }
         if _YamlSchema.has_schema(status_200_response):
             response_schema = _YamlSchema.get_schema_ref(status_200_response)
             print(f"[DEBUG in src] response_schema: {response_schema}")
@@ -237,17 +248,77 @@ class API(Transferable):
                 print(f"[DEBUG in src] response_schema_properties: {response_schema_properties}")
                 for k, v in response_schema_properties.items():
                     print(f"[DEBUG in src] v: {v}")
-                    response_data[k] = self._process_response_value(v)
+                    if strategy is ResponseStrategy.OBJECT:
+                        response_data_prop = self._process_response_value(property_value=v, strategy=strategy)
+                        assert isinstance(response_data_prop, dict)
+                        response_data_prop["name"] = k
+                        response_data_prop["required"] = k in response_schema.get("required", [k])
+                        assert isinstance(
+                            response_data["data"], list
+                        ), "The response data type must be *list* if its HTTP response strategy is object."
+                        response_data["data"].append(response_data_prop)
+                    else:
+                        assert isinstance(
+                            response_data["data"], dict
+                        ), "The response data type must be *dict* if its HTTP response strategy is not object."
+                        response_data["data"][k] = self._process_response_value(property_value=v, strategy=strategy)
         return response_data
 
-    def _process_response_value(self, property_value: dict) -> str:
+    def _process_response_value(self, property_value: dict, strategy: ResponseStrategy) -> Union[str, dict]:
         if _YamlSchema.has_ref(property_value):
             # FIXME: Handle the reference
             v_ref = _YamlSchema.get_schema_ref(property_value)
             print(f"[DEBUG in src] v_ref: {v_ref}")
-            k_value = "FIXME: Handle the reference"
+            if strategy is ResponseStrategy.OBJECT:
+                return {
+                    "name": "",
+                    # TODO: Set the *required* property correctly
+                    "required": True,
+                    # TODO: Set the *type* property correctly
+                    "type": "file",
+                    # TODO: Set the *format* property correctly
+                    "format": None,
+                    "items": [],
+                    "FIXME": "Handle the reference",
+                }
+            else:
+                k_value = "FIXME: Handle the reference"
         else:
             v_type = convert_js_type(property_value["type"])
+            if strategy is ResponseStrategy.OBJECT:
+                if locate(v_type) == list:
+                    response_data_prop = {
+                        "name": "",
+                        # TODO: Set the *required* property correctly
+                        "required": True,
+                        "type": v_type,
+                        # TODO: Set the *format* property correctly
+                        "format": None,
+                        "items": [],
+                    }
+
+                    single_response = _YamlSchema.get_schema_ref(property_value["items"])
+                    single_response_properties = single_response.get("properties", None)
+                    if single_response_properties:
+                        for item_k, item_v in single_response["properties"].items():
+                            item_type = convert_js_type(item_v["type"])
+                            # TODO: Set the *required* property correctly
+                            item = {"name": item_k, "required": True, "type": item_type}
+                            assert isinstance(
+                                response_data_prop["items"], list
+                            ), "The data type of property *items* must be *list*."
+                            response_data_prop["items"].append(item)
+                    return response_data_prop
+                else:
+                    return {
+                        "name": "",
+                        # TODO: Set the *required* property correctly
+                        "required": True,
+                        "type": v_type,
+                        # TODO: Set the *format* property correctly
+                        "format": None,
+                        "items": None,
+                    }
             if locate(v_type) == list:
                 single_response = _YamlSchema.get_schema_ref(property_value["items"])
                 item = {}
@@ -292,7 +363,11 @@ class API(Transferable):
             method=self.http_method.upper(),
             parameters=list(map(lambda p: p.to_api_config(), self.parameters)),
         )
-        mock_api.set_response(value=json.dumps(self.response))
+        resp_strategy = self.response["strategy"]
+        if resp_strategy is ResponseStrategy.OBJECT:
+            mock_api.set_response(strategy=resp_strategy, iterable_value=self.response["data"])
+        else:
+            mock_api.set_response(strategy=resp_strategy, value=self.response["data"])
         return mock_api
 
 

--- a/pymock_api/server/application/process.py
+++ b/pymock_api/server/application/process.py
@@ -124,16 +124,7 @@ class HTTPResponseProcess(BaseHTTPProcess):
             self._get_current_request_http_method(request)
         ]
         response = cast(HTTPResponse, self._ensure_http(api_params_info, "response"))
-        if response.strategy is ResponseStrategy.STRING:
-            response_value = response.value
-        elif response.strategy is ResponseStrategy.FILE:
-            response_value = response.path
-        elif response.strategy is ResponseStrategy.OBJECT:
-            # TODO: Handle the properties as response
-            response_value = response.properties  # type: ignore[assignment]
-        else:
-            raise TypeError
-        return MockHTTPResponse.generate(data=response_value)
+        return MockHTTPResponse.generate(data=response)
 
     def _ensure_http(self, api_config: MockAPI, http_attr: str) -> Union[HTTPRequest, HTTPResponse]:
         assert api_config.http and getattr(

--- a/pymock_api/server/application/response.py
+++ b/pymock_api/server/application/response.py
@@ -78,8 +78,8 @@ class HTTPResponse:
                     value = "random integer"
                 elif locate(v.value_type) is list:
                     value = []  # type: ignore[assignment]
+                    item = {}
                     for i in v.items or []:
-                        item = {}
                         assert i.value_type
                         if locate(i.value_type) is str:
                             item_value = "random string"

--- a/pymock_api/server/application/response.py
+++ b/pymock_api/server/application/response.py
@@ -94,7 +94,7 @@ class HTTPResponse:
                 response[v.name] = value
             return response
         else:
-            raise TypeError
+            raise TypeError(f"Cannot identify invalid HTTP response strategy *{data.strategy}*.")
 
     @classmethod
     def _is_file(cls, path: str) -> bool:

--- a/test/_values.py
+++ b/test/_values.py
@@ -98,6 +98,32 @@ _Test_API_Parameters: List[dict] = [
 ]
 
 
+_Test_Response_Property_Int: dict = {
+    "name": "id",
+    "required": True,
+    "type": "int",
+    "format": None,
+}
+_Test_Response_Property_Str: dict = {
+    "name": "name",
+    "required": True,
+    "type": "str",
+    "format": None,
+}
+_Test_Response_Property_List: dict = {
+    "name": "keys",
+    "required": False,
+    "type": "list",
+    "format": None,
+    "items": _Test_Iterable_Parameter_Items,
+}
+_Test_Response_Properties: List[dict] = [
+    _Test_Response_Property_Int,
+    _Test_Response_Property_Str,
+    _Test_Response_Property_List,
+]
+
+
 def _api_params(iterable_param_type: str) -> List[dict]:
     params = _Test_API_Parameters.copy()
     if iterable_param_type == "single":

--- a/test/_values.py
+++ b/test/_values.py
@@ -97,6 +97,13 @@ _Test_API_Parameters: List[dict] = [
     _Test_API_Parameter_Without_Default,
 ]
 
+# Test HTTP response
+_General_String_Value: str = "This is test message for PyTest."
+_Json_File_Name: str = "test.json"
+_Json_File_Content: dict = {"responseCode": "200", "errorMessage": "OK", "content": "This is YouTube home."}
+_Not_Exist_File_Name: str = "not_exist.json"
+_Not_Json_File_Name: str = "test.yaml"
+_Unexpected_File_Name: str = ".file"
 
 _Test_Response_Property_Int: dict = {
     "name": "id",

--- a/test/_values.py
+++ b/test/_values.py
@@ -118,7 +118,10 @@ _Google_Home_Value: dict = {
             "method": "GET",
             "parameters": _api_params("single"),
         },
-        "response": {"value": "This is Google home API."},
+        "response": {
+            "strategy": "string",
+            "value": "This is Google home API.",
+        },
     },
 }
 
@@ -129,7 +132,10 @@ _Post_Google_Home_Value: dict = {
             "method": "POST",
             "parameters": _api_params("multiple"),
         },
-        "response": {"value": "This is Google home API with POST method."},
+        "response": {
+            "strategy": "string",
+            "value": "This is Google home API with POST method.",
+        },
     },
 }
 
@@ -140,7 +146,10 @@ _Put_Google_Home_Value: dict = {
             "method": "PUT",
             "parameters": [_Test_API_Parameter],
         },
-        "response": {"value": "Change something successfully."},
+        "response": {
+            "strategy": "string",
+            "value": "Change something successfully.",
+        },
     },
 }
 
@@ -150,7 +159,10 @@ _Delete_Google_Home_Value: dict = {
         "request": {
             "method": "DELETE",
         },
-        "response": {"value": "Delete successfully."},
+        "response": {
+            "strategy": "string",
+            "value": "Delete successfully.",
+        },
     },
 }
 
@@ -162,7 +174,10 @@ _Test_Home: dict = {
             "method": "POST",
             "parameters": [_Test_API_Parameter],
         },
-        "response": {"value": '{ "responseCode": "200", "errorMessage": "OK", "content": "This is Test home." }'},
+        "response": {
+            "strategy": "string",
+            "value": '{ "responseCode": "200", "errorMessage": "OK", "content": "This is Test home." }',
+        },
     },
     "cookie": [{"TEST": "cookie_value"}],
 }
@@ -174,7 +189,10 @@ _YouTube_Home_Value: dict = {
         "request": {
             "method": "PUT",
         },
-        "response": {"value": "youtube.json"},
+        "response": {
+            "strategy": "file",
+            "path": "youtube.json",
+        },
     },
     "cookie": [{"USERNAME": "test"}, {"SESSION_EXPIRED": "2023-12-31T00:00:00.000"}],
 }
@@ -205,7 +223,7 @@ _Test_Tag: str = "pytest-mocked-api"
 # Sample configuration content
 class _TestConfig:
     Request: dict = {"method": "GET", "parameters": [_Test_API_Parameter]}
-    Response: Dict[str, str] = {"value": _Test_HTTP_Resp}
+    Response: Dict[str, str] = {"strategy": "string", "value": _Test_HTTP_Resp}
     Http: dict = {"request": Request, "response": Response}
     Mock_API: dict = {"url": _Test_URL, "http": Http, "tag": _Test_Tag}
     Base: dict = {"url": _Base_URL}

--- a/test/_values.py
+++ b/test/_values.py
@@ -226,6 +226,43 @@ _YouTube_Home_Value: dict = {
 _YouTube_API_Content: dict = {"responseCode": "200", "errorMessage": "OK", "content": "This is YouTube home."}
 
 # Sample API for testing ('<base URL>/test' with POST and object type strategy of HTTP response)
+_HTTP_Response_Properties_With_Object_Strategy = [
+    {
+        "name": "id",
+        "required": True,
+        "type": "int",
+        "format": None,
+    },
+    {
+        "name": "role",
+        "required": True,
+        "type": "str",
+        "format": None,
+    },
+    {
+        "name": "details",
+        "required": False,
+        "type": "list",
+        "format": None,
+        "items": [
+            {
+                "name": "name",
+                "required": True,
+                "type": "str",
+            },
+            {
+                "name": "level",
+                "required": True,
+                "type": "int",
+            },
+            {
+                "name": "key",
+                "required": True,
+                "type": "str",
+            },
+        ],
+    },
+]
 _Foo_Object_Value: dict = {
     "url": "/foo-object",
     "http": {
@@ -234,43 +271,7 @@ _Foo_Object_Value: dict = {
         },
         "response": {
             "strategy": "object",
-            "properties": [
-                {
-                    "name": "id",
-                    "required": True,
-                    "type": "int",
-                    "format": None,
-                },
-                {
-                    "name": "role",
-                    "required": True,
-                    "type": "str",
-                    "format": None,
-                },
-                {
-                    "name": "details",
-                    "required": False,
-                    "type": "list",
-                    "format": None,
-                    "items": [
-                        {
-                            "name": "name",
-                            "required": True,
-                            "type": "str",
-                        },
-                        {
-                            "name": "level",
-                            "required": True,
-                            "type": "int",
-                        },
-                        {
-                            "name": "key",
-                            "required": True,
-                            "type": "str",
-                        },
-                    ],
-                },
-            ],
+            "properties": _HTTP_Response_Properties_With_Object_Strategy,
         },
     },
     "cookie": [{"USERNAME": "test"}, {"SESSION_EXPIRED": "2023-12-31T00:00:00.000"}],

--- a/test/_values.py
+++ b/test/_values.py
@@ -338,7 +338,7 @@ _Test_Auto_Type: str = "auto"
 _Test_App_Type: str = "flask"
 _Test_FastAPI_App_Type: str = "fastapi"
 
-# Test subcommand *config* options
+# Test subcommand *add* options
 _Test_SubCommand_Add: str = "add"
 _Test_Response_Strategy: ResponseStrategy = ResponseStrategy.STRING
 
@@ -352,13 +352,13 @@ _Cmd_Arg_API_Path: str = "/foo-home"
 _Cmd_Arg_HTTP_Method: str = "GET"
 _Show_Detail_As_Format: str = "text"
 
-# Test subcommand *config* options
+# Test subcommand *sample* options
 _Test_SubCommand_Sample: str = "sample"
 _Generate_Sample: bool = True
 _Print_Sample: bool = True
 _Sample_File_Path: str = "pytest-api.yaml"
 _Sample_Data_Type: str = "all"
 
-# Test subcommand *config* options
+# Test subcommand *pull* options
 _Test_SubCommand_Pull: str = "pull"
 _API_Doc_Source: str = "127.0.0.1:8080"

--- a/test/_values.py
+++ b/test/_values.py
@@ -225,6 +225,57 @@ _YouTube_Home_Value: dict = {
 
 _YouTube_API_Content: dict = {"responseCode": "200", "errorMessage": "OK", "content": "This is YouTube home."}
 
+# Sample API for testing ('<base URL>/test' with POST and object type strategy of HTTP response)
+_Foo_Object_Value: dict = {
+    "url": "/foo-object",
+    "http": {
+        "request": {
+            "method": "POST",
+        },
+        "response": {
+            "strategy": "object",
+            "properties": [
+                {
+                    "name": "id",
+                    "required": True,
+                    "type": "int",
+                    "format": None,
+                },
+                {
+                    "name": "role",
+                    "required": True,
+                    "type": "str",
+                    "format": None,
+                },
+                {
+                    "name": "details",
+                    "required": False,
+                    "type": "list",
+                    "format": None,
+                    "items": [
+                        {
+                            "name": "name",
+                            "required": True,
+                            "type": "str",
+                        },
+                        {
+                            "name": "level",
+                            "required": True,
+                            "type": "int",
+                        },
+                        {
+                            "name": "key",
+                            "required": True,
+                            "type": "str",
+                        },
+                    ],
+                },
+            ],
+        },
+    },
+    "cookie": [{"USERNAME": "test"}, {"SESSION_EXPIRED": "2023-12-31T00:00:00.000"}],
+}
+
 
 _Mocked_APIs: dict = {
     "base": {"url": _Base_URL},
@@ -234,6 +285,7 @@ _Mocked_APIs: dict = {
     "delete_google_home": _Delete_Google_Home_Value,
     "test_home": _Test_Home,
     "youtube_home": _YouTube_Home_Value,
+    "foo_object": _Foo_Object_Value,
 }
 
 _Test_Config_Value: dict = {

--- a/test/_values.py
+++ b/test/_values.py
@@ -2,6 +2,8 @@ from collections import namedtuple
 from typing import Dict, List
 from unittest.mock import Mock
 
+from pymock_api.model.enums import ResponseStrategy
+
 
 class APIConfigValue:
     @property
@@ -338,6 +340,7 @@ _Test_FastAPI_App_Type: str = "fastapi"
 
 # Test subcommand *config* options
 _Test_SubCommand_Add: str = "add"
+_Test_Response_Strategy: ResponseStrategy = ResponseStrategy.STRING
 
 # Test subcommand *check* options
 _Test_SubCommand_Check: str = "check"

--- a/test/data/check_test/config/invalid/mockapis_api_name_http_request_method-with_invalid_value.yaml
+++ b/test/data/check_test/config/invalid/mockapis_api_name_http_request_method-with_invalid_value.yaml
@@ -5,4 +5,5 @@ mocked_apis:
       request:
         method: 'INVALID'
       response:
+        strategy: string
         value: 'This is Google home API.'

--- a/test/data/check_test/config/invalid/mockapis_api_name_http_response_object-with_miss_name.yaml
+++ b/test/data/check_test/config/invalid/mockapis_api_name_http_response_object-with_miss_name.yaml
@@ -1,0 +1,10 @@
+mocked_apis:
+  google_home:
+    url: '/google'
+    http:
+      request:
+        method: 'GET'
+      response:
+        strategy: object
+        properties:
+          - no_name: for_test_checking_invalid_attribute

--- a/test/data/check_test/config/invalid/mockapis_api_name_http_response_object-with_miss_required.yaml
+++ b/test/data/check_test/config/invalid/mockapis_api_name_http_response_object-with_miss_required.yaml
@@ -1,0 +1,11 @@
+mocked_apis:
+  google_home:
+    url: '/google'
+    http:
+      request:
+        method: 'GET'
+      response:
+        strategy: object
+        properties:
+          - name: name
+            no_required: for_test_checking_invalid_attribute

--- a/test/data/check_test/config/invalid/mockapis_api_name_http_response_object-with_miss_type.yaml
+++ b/test/data/check_test/config/invalid/mockapis_api_name_http_response_object-with_miss_type.yaml
@@ -1,0 +1,12 @@
+mocked_apis:
+  google_home:
+    url: '/google'
+    http:
+      request:
+        method: 'GET'
+      response:
+        strategy: object
+        properties:
+          - name: name
+            required: True
+            no_type: for_test_checking_invalid_attribute

--- a/test/data/check_test/config/invalid/mockapis_api_name_http_response_string-with_invalid_value.yaml
+++ b/test/data/check_test/config/invalid/mockapis_api_name_http_response_string-with_invalid_value.yaml
@@ -1,0 +1,9 @@
+mocked_apis:
+  google_home:
+    url: '/google'
+    http:
+      request:
+        method: 'GET'
+      response:
+        strategy: string
+        value: "{invalid JSON format string}"

--- a/test/data/check_test/config/invalid/mockapis_api_name_http_response_value-with_invalid_strategy.yaml
+++ b/test/data/check_test/config/invalid/mockapis_api_name_http_response_value-with_invalid_strategy.yaml
@@ -1,0 +1,8 @@
+mocked_apis:
+  google_home:
+    url: '/google'
+    http:
+      request:
+        method: 'GET'
+      response:
+        strategy: invalid_strategy

--- a/test/data/check_test/config/invalid/mockapis_api_name_http_response_value-with_not_exist_file.yaml
+++ b/test/data/check_test/config/invalid/mockapis_api_name_http_response_value-with_not_exist_file.yaml
@@ -5,4 +5,5 @@ mocked_apis:
       request:
         method: 'GET'
       response:
-        value: ./not_exist.file
+        strategy: file
+        path: ./not_exist.file

--- a/test/data/check_test/config/invalid/no_mockapis_api_name_http_request.yaml
+++ b/test/data/check_test/config/invalid/no_mockapis_api_name_http_request.yaml
@@ -4,4 +4,5 @@ mocked_apis:
     http:
       request:
       response:
+        strategy: string
         value: 'This is Google home API.'

--- a/test/data/check_test/config/invalid/no_mockapis_api_name_http_request_method.yaml
+++ b/test/data/check_test/config/invalid/no_mockapis_api_name_http_request_method.yaml
@@ -5,4 +5,5 @@ mocked_apis:
       request:
         method:
       response:
+        strategy: string
         value: 'This is Google home API.'

--- a/test/data/check_test/config/invalid/no_mockapis_api_name_http_response_value.yaml
+++ b/test/data/check_test/config/invalid/no_mockapis_api_name_http_response_value.yaml
@@ -5,4 +5,5 @@ mocked_apis:
       request:
         method: 'GET'
       response:
+        strategy: string
         value:

--- a/test/data/check_test/config/valid/sample-with_general_string_value.yaml
+++ b/test/data/check_test/config/valid/sample-with_general_string_value.yaml
@@ -5,4 +5,5 @@ mocked_apis:
       request:
         method: 'GET'
       response:
+        strategy: string
         value: 'This is Google home.'

--- a/test/data/check_test/config/valid/sample-with_json_data.yaml
+++ b/test/data/check_test/config/valid/sample-with_json_data.yaml
@@ -5,4 +5,5 @@ mocked_apis:
       request:
         method: 'GET'
       response:
+        strategy: string
         value: '{"responseCode": 200, "responseData": {"content": "This is sample response as JSON format", "errorMsg": ""}}'

--- a/test/data/check_test/config/valid/sample-with_json_file.yaml
+++ b/test/data/check_test/config/valid/sample-with_json_file.yaml
@@ -6,4 +6,5 @@ mocked_apis:
         method: 'GET'
       response:
         # Note: The root directory it (PyTest) runs is project root directory.
-        value: ./test/data/check_test/config/valid/response.json
+        strategy: file
+        path: ./test/data/check_test/config/valid/response.json

--- a/test/data/check_test/config/valid/sample-with_object.yaml
+++ b/test/data/check_test/config/valid/sample-with_object.yaml
@@ -1,0 +1,25 @@
+mocked_apis:
+  google_home:
+    url: '/google'
+    http:
+      request:
+        method: 'GET'
+      response:
+        strategy: object
+        properties:
+          - name: responseCode
+            required: True
+            type: int
+            format:
+          - name: responseData
+            required: True
+            type: str
+            format:
+#            items:
+#              content: '{"content": "This is sample response as JSON format", "errorMsg": ""}'
+#          - name: responseData
+#            required: True
+#            type: dict
+#            items:
+#              content: "This is sample response as JSON format"
+#              errorMsg: ""

--- a/test/data/check_test/diff_with_swagger/config/invalid/incorrect_parameter-boolean-type.yaml
+++ b/test/data/check_test/diff_with_swagger/config/invalid/incorrect_parameter-boolean-type.yaml
@@ -18,4 +18,5 @@ mocked_apis:
             type: str
             default: 'false'
       response:
+        strategy: 'string'
         value: 'This is Foo home API.'

--- a/test/data/check_test/diff_with_swagger/config/invalid/incorrect_parameter-default.yaml
+++ b/test/data/check_test/diff_with_swagger/config/invalid/incorrect_parameter-default.yaml
@@ -10,4 +10,5 @@ mocked_apis:
             type: str
             default: 'incorrect default value'
       response:
+        strategy: 'string'
         value: 'This is Foo home API.'

--- a/test/data/check_test/diff_with_swagger/config/invalid/incorrect_parameter-integer-type.yaml
+++ b/test/data/check_test/diff_with_swagger/config/invalid/incorrect_parameter-integer-type.yaml
@@ -14,4 +14,5 @@ mocked_apis:
             type: str
             default: '0'
       response:
+        strategy: 'string'
         value: 'This is Foo home API.'

--- a/test/data/check_test/diff_with_swagger/config/invalid/incorrect_parameter-required.yaml
+++ b/test/data/check_test/diff_with_swagger/config/invalid/incorrect_parameter-required.yaml
@@ -10,4 +10,5 @@ mocked_apis:
             type: str
             default: 'arg1_default_value'
       response:
+        strategy: 'string'
         value: 'This is Foo home API.'

--- a/test/data/check_test/diff_with_swagger/config/invalid/incorrect_parameter-string-type.yaml
+++ b/test/data/check_test/diff_with_swagger/config/invalid/incorrect_parameter-string-type.yaml
@@ -10,4 +10,5 @@ mocked_apis:
             type: int
             default: 'arg1_default_value'
       response:
+        strategy: 'string'
         value: 'This is Foo home API.'

--- a/test/data/check_test/diff_with_swagger/config/invalid/miss_api.yaml
+++ b/test/data/check_test/diff_with_swagger/config/invalid/miss_api.yaml
@@ -5,4 +5,5 @@ mocked_apis:
       request:
         method: 'GET'
       response:
+        strategy: 'string'
         value: 'This is Test home API.'

--- a/test/data/check_test/diff_with_swagger/config/invalid/miss_method.yaml
+++ b/test/data/check_test/diff_with_swagger/config/invalid/miss_method.yaml
@@ -10,4 +10,5 @@ mocked_apis:
             type: str
             default: 'arg1_default_value'
       response:
+        strategy: 'string'
         value: 'This is Foo home API.'

--- a/test/data/check_test/diff_with_swagger/config/invalid/miss_parameter.yaml
+++ b/test/data/check_test/diff_with_swagger/config/invalid/miss_parameter.yaml
@@ -10,4 +10,5 @@ mocked_apis:
             type: str
             default: 'missing'
       response:
+        strategy: 'string'
         value: 'This is Foo home API.'

--- a/test/data/check_test/diff_with_swagger/config/valid/has-base-info_test.yaml
+++ b/test/data/check_test/diff_with_swagger/config/valid/has-base-info_test.yaml
@@ -20,4 +20,5 @@ mocked_apis:
             type: bool
             default: false
       response:
+        strategy: 'string'
         value: 'This is Foo home API.'

--- a/test/data/check_test/diff_with_swagger/config/valid/no-base-info_test.yaml
+++ b/test/data/check_test/diff_with_swagger/config/valid/no-base-info_test.yaml
@@ -18,4 +18,5 @@ mocked_apis:
             type: bool
             default: false
       response:
+        strategy: 'string'
         value: 'This is Foo home API.'

--- a/test/data/get_test/invalid/warn/empty-http-request.yaml
+++ b/test/data/get_test/invalid/warn/empty-http-request.yaml
@@ -4,4 +4,5 @@ mocked_apis:
     http:
       request:
       response:
+        strategy: string
         value: 'This is Foo home API.'

--- a/test/data/get_test/valid/simple.yaml
+++ b/test/data/get_test/valid/simple.yaml
@@ -18,4 +18,5 @@ mocked_apis:
             type: bool
             default: false
       response:
+        strategy: string
         value: 'This is Foo home API.'

--- a/test/data/pull_test/config/has-base-info_and_tags_test.yaml
+++ b/test/data/pull_test/config/has-base-info_and_tags_test.yaml
@@ -20,8 +20,33 @@ mocked_apis:
             type: str
             format:
       response:
-        strategy: string
-        value: '{"errorMessage": "random string value", "responseCode": "random string value", "responseData": [{"id": "random integer value", "name": "random string value", "value1": "random string value", "value2": "random string value"}]}'
+        strategy: object
+        properties:
+          - name: errorMessage
+            required: True
+            type: str
+            format:
+          - name: responseCode
+            required: True
+            type: str
+            format:
+          - name: responseData
+            required: False
+            type: list
+            format:
+            items:
+              - name: id
+                required: True
+                type: int
+              - name: name
+                required: True
+                type: str
+              - name: value1
+                required: True
+                type: str
+              - name: value2
+                required: True
+                type: str
     tag: 'foo'
   put_foo:
     url: '/foo'
@@ -42,8 +67,20 @@ mocked_apis:
                 type: int
                 name: "id"
       response:
-        strategy: string
-        value: '{"errorMessage": "random string value", "responseCode": "random string value", "responseData": [{}]}'
+        strategy: object
+        properties:
+          - name: errorMessage
+            required: True
+            type: str
+            format:
+          - name: responseCode
+            required: True
+            type: str
+            format:
+          - name: responseData
+            required: False
+            type: list
+            format:
     tag: 'foo'
   get_foo_boo_export:
     url: '/foo-boo/export'
@@ -70,6 +107,40 @@ mocked_apis:
             type: str
             format:
       response:
-        strategy: string
-        value: '{"description": "random string value", "file": "random file output stream", "filename": "random string value", "inputStream": "FIXME: Handle the reference", "open": "random boolean value", "readable": "random boolean value", "uri": "random string value", "url": "random string value"}'
+        strategy: object
+        properties:
+          - name: description
+            required: True
+            type: str
+            format:
+          # TODO: implement file stream
+          - name: file
+            required: True
+            type: file
+            format:
+          - name: filename
+            required: True
+            type: str
+            format:
+          # TODO: implement file stream
+          - name: inputStream
+            required: True
+            type: file
+            format:
+          - name: open
+            required: True
+            type: bool
+            format:
+          - name: readable
+            required: True
+            type: bool
+            format:
+          - name: uri
+            required: True
+            type: str
+            format:
+          - name: url
+            required: True
+            type: str
+            format:
     tag: 'foo-boo'

--- a/test/data/pull_test/config/has-base-info_and_tags_test.yaml
+++ b/test/data/pull_test/config/has-base-info_and_tags_test.yaml
@@ -20,6 +20,7 @@ mocked_apis:
             type: str
             format:
       response:
+        strategy: string
         value: '{"errorMessage": "random string value", "responseCode": "random string value", "responseData": [{"id": "random integer value", "name": "random string value", "value1": "random string value", "value2": "random string value"}]}'
     tag: 'foo'
   put_foo:
@@ -41,6 +42,7 @@ mocked_apis:
                 type: int
                 name: "id"
       response:
+        strategy: string
         value: '{"errorMessage": "random string value", "responseCode": "random string value", "responseData": [{}]}'
     tag: 'foo'
   get_foo_boo_export:
@@ -68,5 +70,6 @@ mocked_apis:
             type: str
             format:
       response:
+        strategy: string
         value: '{"description": "random string value", "file": "random file output stream", "filename": "random string value", "inputStream": "FIXME: Handle the reference", "open": "random boolean value", "readable": "random boolean value", "uri": "random string value", "url": "random string value"}'
     tag: 'foo-boo'

--- a/test/data/pull_test/config/has-base-info_test.yaml
+++ b/test/data/pull_test/config/has-base-info_test.yaml
@@ -25,5 +25,6 @@ mocked_apis:
             default: false
             format:
       response:
+        strategy: string
         value: '{}'
     tag: ''

--- a/test/data/pull_test/config/has-base-info_test.yaml
+++ b/test/data/pull_test/config/has-base-info_test.yaml
@@ -25,6 +25,6 @@ mocked_apis:
             default: false
             format:
       response:
-        strategy: string
-        value: '{}'
+        strategy: object
+        properties: []
     tag: ''

--- a/test/data/pull_test/config/no-base-info_test.yaml
+++ b/test/data/pull_test/config/no-base-info_test.yaml
@@ -24,6 +24,6 @@ mocked_apis:
             default: false
             format:
       response:
-        strategy: string
-        value: '{}'
+        strategy: object
+        properties: []
     tag: ''

--- a/test/data/pull_test/config/no-base-info_test.yaml
+++ b/test/data/pull_test/config/no-base-info_test.yaml
@@ -24,5 +24,6 @@ mocked_apis:
             default: false
             format:
       response:
+        strategy: string
         value: '{}'
     tag: ''

--- a/test/integration_test/server/application/init.py
+++ b/test/integration_test/server/application/init.py
@@ -17,6 +17,7 @@ from pymock_api.server.application.response import HTTPResponse as _HTTPResponse
 from ...._values import (
     _Base_URL,
     _Delete_Google_Home_Value,
+    _Foo_Object_Value,
     _Google_Home_Value,
     _Post_Google_Home_Value,
     _Put_Google_Home_Value,
@@ -96,6 +97,7 @@ class MockHTTPServerTestSpec:
             _test_api_attr(api=_Delete_Google_Home_Value, payload={}),
             _test_api_attr(api=_Test_Home, payload={"param1": "any_format"}),
             _test_api_attr(api=_YouTube_Home_Value, payload={"param1": "any_format"}),
+            _test_api_attr(api=_Foo_Object_Value, payload={"param1": "any_format"}),
         ],
     )
     def test_mock_apis(

--- a/test/integration_test/server/application/init.py
+++ b/test/integration_test/server/application/init.py
@@ -11,6 +11,7 @@ from httpx import Response as FastAPIResponse
 
 from pymock_api.model import APIConfig, load_config
 from pymock_api.model.api_config import APIParameter, MockAPI
+from pymock_api.model.enums import ResponseStrategy
 from pymock_api.server.application import BaseAppServer, FastAPIServer, FlaskServer
 from pymock_api.server.application.response import HTTPResponse as _HTTPResponse
 
@@ -135,7 +136,17 @@ class MockHTTPServerTestSpec:
         under_test_http_resp = self._deserialize_response(response)
 
         # Get the expected result data
-        expected_http_resp = _HTTPResponse.generate(data=one_api_configs[http_method.upper()].http.response.value)  # type: ignore[union-attr]
+        config_response = one_api_configs[http_method.upper()].http.response  # type: ignore[union-attr]
+        if config_response.strategy is ResponseStrategy.STRING:  # type: ignore[union-attr]
+            response_value = config_response.value  # type: ignore[union-attr]
+        elif config_response.strategy is ResponseStrategy.FILE:  # type: ignore[union-attr]
+            response_value = config_response.path  # type: ignore[union-attr]
+        elif config_response.strategy is ResponseStrategy.OBJECT:  # type: ignore[union-attr]
+            # TODO: Handle the properties
+            response_value = config_response.properties  # type: ignore[union-attr]
+        else:
+            assert False, f"Exist incorrect HTTP response strategy *{config_response.strategy}* in test."  # type: ignore[union-attr]
+        expected_http_resp = _HTTPResponse.generate(data=response_value)
 
         # Verify the result data
         assert (

--- a/test/integration_test/server/application/init.py
+++ b/test/integration_test/server/application/init.py
@@ -137,16 +137,16 @@ class MockHTTPServerTestSpec:
 
         # Get the expected result data
         config_response = one_api_configs[http_method.upper()].http.response  # type: ignore[union-attr]
-        if config_response.strategy is ResponseStrategy.STRING:  # type: ignore[union-attr]
-            response_value = config_response.value  # type: ignore[union-attr]
-        elif config_response.strategy is ResponseStrategy.FILE:  # type: ignore[union-attr]
-            response_value = config_response.path  # type: ignore[union-attr]
-        elif config_response.strategy is ResponseStrategy.OBJECT:  # type: ignore[union-attr]
-            # TODO: Handle the properties
-            response_value = config_response.properties  # type: ignore[union-attr]
-        else:
-            assert False, f"Exist incorrect HTTP response strategy *{config_response.strategy}* in test."  # type: ignore[union-attr]
-        expected_http_resp = _HTTPResponse.generate(data=response_value)
+        # if config_response.strategy is ResponseStrategy.STRING:  # type: ignore[union-attr]
+        #     response_value = config_response.value  # type: ignore[union-attr]
+        # elif config_response.strategy is ResponseStrategy.FILE:  # type: ignore[union-attr]
+        #     response_value = config_response.path  # type: ignore[union-attr]
+        # elif config_response.strategy is ResponseStrategy.OBJECT:  # type: ignore[union-attr]
+        #     # TODO: Handle the properties
+        #     response_value = config_response.properties  # type: ignore[union-attr]
+        # else:
+        #     assert False, f"Exist incorrect HTTP response strategy *{config_response.strategy}* in test."  # type: ignore[union-attr]
+        expected_http_resp = _HTTPResponse.generate(data=config_response)  # type: ignore[arg-type]
 
         # Verify the result data
         assert (

--- a/test/integration_test/server/application/init.py
+++ b/test/integration_test/server/application/init.py
@@ -11,7 +11,6 @@ from httpx import Response as FastAPIResponse
 
 from pymock_api.model import APIConfig, load_config
 from pymock_api.model.api_config import APIParameter, MockAPI
-from pymock_api.model.enums import ResponseStrategy
 from pymock_api.server.application import BaseAppServer, FastAPIServer, FlaskServer
 from pymock_api.server.application.response import HTTPResponse as _HTTPResponse
 
@@ -137,49 +136,12 @@ class MockHTTPServerTestSpec:
 
         # Get the expected result data
         config_response = one_api_configs[http_method.upper()].http.response  # type: ignore[union-attr]
-        # if config_response.strategy is ResponseStrategy.STRING:  # type: ignore[union-attr]
-        #     response_value = config_response.value  # type: ignore[union-attr]
-        # elif config_response.strategy is ResponseStrategy.FILE:  # type: ignore[union-attr]
-        #     response_value = config_response.path  # type: ignore[union-attr]
-        # elif config_response.strategy is ResponseStrategy.OBJECT:  # type: ignore[union-attr]
-        #     # TODO: Handle the properties
-        #     response_value = config_response.properties  # type: ignore[union-attr]
-        # else:
-        #     assert False, f"Exist incorrect HTTP response strategy *{config_response.strategy}* in test."  # type: ignore[union-attr]
         expected_http_resp = _HTTPResponse.generate(data=config_response)  # type: ignore[arg-type]
 
         # Verify the result data
         assert (
             under_test_http_resp == expected_http_resp
         ), f"The response data should be the same at mocked API '{one_api_configs[http_method.upper()]}'."
-
-        # for one_api_name, one_api_config in api_config.apis.apis.items():
-        #     # Send HTTP request to target API and get its response data
-        #     assert (
-        #         one_api_config
-        #         and one_api_config.http
-        #         and one_api_config.http.request
-        #         and one_api_config.http.request.method
-        #         and api_config.apis.base
-        #         and one_api_config.url
-        #     )
-        #     if one_api_config.http.request.method.lower() == "get":
-        #         params = self._client_get_req_func_params(one_api_config)
-        #     else:
-        #         params = self._client_non_get_req_func_params(one_api_config)
-        #     response = getattr(client, one_api_config.http.request.method.lower())(
-        #         api_config.apis.base.url + one_api_config.url, **params
-        #     )
-        #     under_test_http_resp = self._deserialize_response(response)
-        #
-        #     # Get the expected result data
-        #     assert one_api_config.http.response
-        #     expected_http_resp = _HTTPResponse.generate(data=one_api_config.http.response.value)
-        #
-        #     # Verify the result data
-        #     assert (
-        #         under_test_http_resp == expected_http_resp
-        #     ), f"The response data should be the same at mocked API '{one_api_name}'."
 
     def _client_non_get_req_func_params(self, one_api_config: MockAPI) -> dict:
         params = one_api_config.http.request.parameters  # type: ignore[union-attr]

--- a/test/unit_test/command/add/component.py
+++ b/test/unit_test/command/add/component.py
@@ -9,6 +9,7 @@ from pymock_api._utils.file_opt import YAML
 from pymock_api.command.add.component import SubCmdAddComponent
 from pymock_api.model import generate_empty_config
 from pymock_api.model.cmd_args import SubcmdAddArguments
+from pymock_api.model.enums import ResponseStrategy
 
 from ...._values import (
     _Test_Config,
@@ -88,12 +89,13 @@ class TestSubCmdAddComponent:
                         mock_generate_empty_config.assert_called_once()
 
     @pytest.mark.parametrize(
-        ("http_method", "parameters", "response_value"),
+        ("http_method", "parameters", "response_strategy", "response_value"),
         [
-            (None, [], None),
+            (None, [], _Test_Response_Strategy, None),
             (
                 "POST",
                 [{"name": "arg1", "required": False, "default": "val1", "type": "str"}],
+                _Test_Response_Strategy,
                 ["This is PyTest response"],
             ),
         ],
@@ -102,6 +104,7 @@ class TestSubCmdAddComponent:
         self,
         http_method: Optional[str],
         parameters: List[dict],
+        response_strategy: ResponseStrategy,
         response_value: Optional[List[str]],
         component: SubCmdAddComponent,
     ):
@@ -117,8 +120,7 @@ class TestSubCmdAddComponent:
                     api_path=_Test_URL,
                     http_method=http_method,
                     parameters=parameters,
-                    # TODO: Change to use parameter to set it
-                    response_strategy=_Test_Response_Strategy,
+                    response_strategy=response_strategy,
                     response_value=response_value,
                 )
                 component.process(args)
@@ -131,24 +133,27 @@ class TestSubCmdAddComponent:
                 FakeYAML.write.assert_called_once_with(path=_Test_Config, config=api_config.serialize())
 
     @pytest.mark.parametrize(
-        ("url_path", "http_method", "parameters", "response_value"),
+        ("url_path", "http_method", "parameters", "response_strategy", "response_value"),
         [
             (
                 None,
                 "POST",
                 [{"name": "arg1", "required": False, "default": "val1", "type": "str"}],
+                _Test_Response_Strategy,
                 ["This is PyTest response"],
             ),
             (
                 "",
                 "POST",
                 [{"name": "arg1", "required": False, "default": "val1", "type": "str"}],
+                _Test_Response_Strategy,
                 ["This is PyTest response"],
             ),
             (
                 _Test_URL,
                 "POST",
                 [{"name": "arg1", "required": False, "default": "val1", "type": "str", "invalid_key": "val"}],
+                _Test_Response_Strategy,
                 ["This is PyTest response"],
             ),
         ],
@@ -158,6 +163,7 @@ class TestSubCmdAddComponent:
         url_path: str,
         http_method: Optional[str],
         parameters: List[dict],
+        response_strategy: ResponseStrategy,
         response_value: Optional[List[str]],
         component: SubCmdAddComponent,
     ):
@@ -173,8 +179,7 @@ class TestSubCmdAddComponent:
                     api_path=url_path,
                     http_method=http_method,
                     parameters=parameters,
-                    # TODO: Change to use parameter to set it
-                    response_strategy=_Test_Response_Strategy,
+                    response_strategy=response_strategy,
                     response_value=response_value,
                 )
                 with pytest.raises(SystemExit) as exc_info:

--- a/test/unit_test/command/add/component.py
+++ b/test/unit_test/command/add/component.py
@@ -38,7 +38,7 @@ class TestSubCmdAddComponent:
             http_method="",
             parameters=[],
             response_strategy=_Test_Response_Strategy,
-            response="",
+            response_value=[""],
         )
 
         # Run target function to test
@@ -72,7 +72,7 @@ class TestSubCmdAddComponent:
                         http_method="GET",
                         parameters=[],
                         response_strategy=_Test_Response_Strategy,
-                        response="OK",
+                        response_value=["OK"],
                     )
                     component._get_api_config(args)
 
@@ -115,7 +115,7 @@ class TestSubCmdAddComponent:
                     parameters=parameters,
                     # TODO: Change to use parameter to set it
                     response_strategy=_Test_Response_Strategy,
-                    response=response,
+                    response_value=[response],
                 )
                 component.process(args)
 
@@ -171,7 +171,7 @@ class TestSubCmdAddComponent:
                     parameters=parameters,
                     # TODO: Change to use parameter to set it
                     response_strategy=_Test_Response_Strategy,
-                    response=response,
+                    response_value=[response],
                 )
                 with pytest.raises(SystemExit) as exc_info:
                     component.process(args)

--- a/test/unit_test/command/add/component.py
+++ b/test/unit_test/command/add/component.py
@@ -10,7 +10,12 @@ from pymock_api.command.add.component import SubCmdAddComponent
 from pymock_api.model import generate_empty_config
 from pymock_api.model.cmd_args import SubcmdAddArguments
 
-from ...._values import _Test_Config, _Test_SubCommand_Add, _Test_URL
+from ...._values import (
+    _Test_Config,
+    _Test_Response_Strategy,
+    _Test_SubCommand_Add,
+    _Test_URL,
+)
 
 
 class FakeYAML(YAML):
@@ -32,6 +37,7 @@ class TestSubCmdAddComponent:
             api_path="",
             http_method="",
             parameters=[],
+            response_strategy=_Test_Response_Strategy,
             response="",
         )
 
@@ -65,6 +71,7 @@ class TestSubCmdAddComponent:
                         api_path=_Test_URL,
                         http_method="GET",
                         parameters=[],
+                        response_strategy=_Test_Response_Strategy,
                         response="OK",
                     )
                     component._get_api_config(args)
@@ -106,6 +113,8 @@ class TestSubCmdAddComponent:
                     api_path=_Test_URL,
                     http_method=http_method,
                     parameters=parameters,
+                    # TODO: Change to use parameter to set it
+                    response_strategy=_Test_Response_Strategy,
                     response=response,
                 )
                 component.process(args)
@@ -160,6 +169,8 @@ class TestSubCmdAddComponent:
                     api_path=url_path,
                     http_method=http_method,
                     parameters=parameters,
+                    # TODO: Change to use parameter to set it
+                    response_strategy=_Test_Response_Strategy,
                     response=response,
                 )
                 with pytest.raises(SystemExit) as exc_info:

--- a/test/unit_test/command/add/component.py
+++ b/test/unit_test/command/add/component.py
@@ -88,18 +88,22 @@ class TestSubCmdAddComponent:
                         mock_generate_empty_config.assert_called_once()
 
     @pytest.mark.parametrize(
-        ("http_method", "parameters", "response"),
+        ("http_method", "parameters", "response_value"),
         [
             (None, [], None),
             (
                 "POST",
                 [{"name": "arg1", "required": False, "default": "val1", "type": "str"}],
-                "This is PyTest response",
+                ["This is PyTest response"],
             ),
         ],
     )
     def test_add_valid_api(
-        self, http_method: Optional[str], parameters: List[dict], response: Optional[str], component: SubCmdAddComponent
+        self,
+        http_method: Optional[str],
+        parameters: List[dict],
+        response_value: Optional[List[str]],
+        component: SubCmdAddComponent,
     ):
         # Mock functions
         FakeYAML.serialize = MagicMock()
@@ -115,7 +119,7 @@ class TestSubCmdAddComponent:
                     parameters=parameters,
                     # TODO: Change to use parameter to set it
                     response_strategy=_Test_Response_Strategy,
-                    response_value=[response],
+                    response_value=response_value,
                 )
                 component.process(args)
 
@@ -127,25 +131,25 @@ class TestSubCmdAddComponent:
                 FakeYAML.write.assert_called_once_with(path=_Test_Config, config=api_config.serialize())
 
     @pytest.mark.parametrize(
-        ("url_path", "http_method", "parameters", "response"),
+        ("url_path", "http_method", "parameters", "response_value"),
         [
             (
                 None,
                 "POST",
                 [{"name": "arg1", "required": False, "default": "val1", "type": "str"}],
-                "This is PyTest response",
+                ["This is PyTest response"],
             ),
             (
                 "",
                 "POST",
                 [{"name": "arg1", "required": False, "default": "val1", "type": "str"}],
-                "This is PyTest response",
+                ["This is PyTest response"],
             ),
             (
                 _Test_URL,
                 "POST",
                 [{"name": "arg1", "required": False, "default": "val1", "type": "str", "invalid_key": "val"}],
-                "This is PyTest response",
+                ["This is PyTest response"],
             ),
         ],
     )
@@ -154,7 +158,7 @@ class TestSubCmdAddComponent:
         url_path: str,
         http_method: Optional[str],
         parameters: List[dict],
-        response: Optional[str],
+        response_value: Optional[List[str]],
         component: SubCmdAddComponent,
     ):
         # Mock functions
@@ -171,7 +175,7 @@ class TestSubCmdAddComponent:
                     parameters=parameters,
                     # TODO: Change to use parameter to set it
                     response_strategy=_Test_Response_Strategy,
-                    response_value=[response],
+                    response_value=response_value,
                 )
                 with pytest.raises(SystemExit) as exc_info:
                     component.process(args)

--- a/test/unit_test/command/add/component.py
+++ b/test/unit_test/command/add/component.py
@@ -98,6 +98,15 @@ class TestSubCmdAddComponent:
                 _Test_Response_Strategy,
                 ["This is PyTest response"],
             ),
+            (
+                "PUT",
+                [{"name": "arg1", "required": False, "default": "val1", "type": "str"}],
+                ResponseStrategy.OBJECT,
+                [
+                    {"name": "id", "required": True, "type": "int", "format": None, "items": None},
+                    {"name": "name", "required": True, "type": "str", "format": None, "items": None},
+                ],
+            ),
         ],
     )
     def test_add_valid_api(
@@ -155,6 +164,13 @@ class TestSubCmdAddComponent:
                 [{"name": "arg1", "required": False, "default": "val1", "type": "str", "invalid_key": "val"}],
                 _Test_Response_Strategy,
                 ["This is PyTest response"],
+            ),
+            (
+                _Test_URL,
+                "PUT",
+                [{"name": "arg1", "required": False, "default": "val1", "type": "str"}],
+                _Test_Response_Strategy,
+                [{"invalid data structure": ""}],
             ),
         ],
     )

--- a/test/unit_test/command/check/component.py
+++ b/test/unit_test/command/check/component.py
@@ -184,6 +184,27 @@ class TestSubCmdCheckComponent:
                     subcmd.process(mock_parser_arg)
                 assert expected_exit_code in str(exc_info.value)
 
+    @pytest.mark.parametrize(
+        ("mock_exception", "stop_if_fail"),
+        [
+            (RuntimeError, True),
+            (ValueError("not match invalid strategy error message"), True),
+            (RuntimeError, False),
+            (ValueError("not match invalid strategy error message"), False),
+        ],
+    )
+    def test_process_raise_unexpected_exception(
+        self, mock_exception: Exception, stop_if_fail: bool, subcmd: SubCmdCheckComponent
+    ):
+        mock_parser_arg = _given_parser_args(
+            subcommand=_Test_SubCommand_Check, swagger_doc_url=_Swagger_API_Document_URL, stop_if_fail=stop_if_fail
+        )
+        MagicMock()
+        with patch("pymock_api.command.check.component.load_config", side_effect=mock_exception) as mock_load_config:
+            with pytest.raises(Exception):
+                subcmd.process(mock_parser_arg)
+            mock_load_config.assert_called_once()
+
 
 class TestValidityChecking:
     @pytest.fixture(scope="class")

--- a/test/unit_test/command/process.py
+++ b/test/unit_test/command/process.py
@@ -389,33 +389,40 @@ class TestSubCmdAdd(BaseCommandProcessorTestSpec):
         return SubCmdAdd()
 
     @pytest.mark.parametrize(
-        ("url_path", "method", "params", "response_value"),
+        ("url_path", "method", "params", "response_strategy", "response_value"),
         [
-            ("/foo", "", [], [""]),
-            ("/foo", "GET", [], [""]),
-            ("/foo", "POST", [], ["This is PyTest response"]),
-            ("/foo", "PUT", [], ["Wow testing."]),
+            ("/foo", "", [], _Test_Response_Strategy, [""]),
+            ("/foo", "GET", [], _Test_Response_Strategy, [""]),
+            ("/foo", "POST", [], _Test_Response_Strategy, ["This is PyTest response"]),
+            ("/foo", "PUT", [], _Test_Response_Strategy, ["Wow testing."]),
         ],
     )
     def test_with_command_processor(
-        self, url_path: str, method: str, params: List[dict], response_value: List[str], object_under_test: Callable
+        self,
+        url_path: str,
+        method: str,
+        params: List[dict],
+        response_strategy: ResponseStrategy,
+        response_value: List[str],
+        object_under_test: Callable,
     ):
         kwargs = {
             "url_path": url_path,
             "method": method,
             "params": params,
+            "response_strategy": response_strategy,
             "response_value": response_value,
             "cmd_ps": object_under_test,
         }
         self._test_process(**kwargs)
 
     @pytest.mark.parametrize(
-        ("url_path", "method", "params", "response_value"),
+        ("url_path", "method", "params", "response_strategy", "response_value"),
         [
-            ("/foo", "", "", [""]),
-            ("/foo", "GET", [], [""]),
-            ("/foo", "POST", [], ["This is PyTest response"]),
-            ("/foo", "PUT", [], ["Wow testing."]),
+            ("/foo", "", "", _Test_Response_Strategy, [""]),
+            ("/foo", "GET", [], _Test_Response_Strategy, [""]),
+            ("/foo", "POST", [], _Test_Response_Strategy, ["This is PyTest response"]),
+            ("/foo", "PUT", [], _Test_Response_Strategy, ["Wow testing."]),
         ],
     )
     def test_with_run_entry_point(
@@ -423,6 +430,7 @@ class TestSubCmdAdd(BaseCommandProcessorTestSpec):
         url_path: str,
         method: str,
         params: List[dict],
+        response_strategy: ResponseStrategy,
         response_value: List[str],
         entry_point_under_test: Callable,
     ):
@@ -430,13 +438,20 @@ class TestSubCmdAdd(BaseCommandProcessorTestSpec):
             "url_path": url_path,
             "method": method,
             "params": params,
+            "response_strategy": response_strategy,
             "response_value": response_value,
             "cmd_ps": entry_point_under_test,
         }
         self._test_process(**kwargs)
 
     def _test_process(
-        self, url_path: str, method: str, params: List[dict], response_value: List[str], cmd_ps: Callable
+        self,
+        url_path: str,
+        method: str,
+        params: List[dict],
+        response_strategy: ResponseStrategy,
+        response_value: List[str],
+        cmd_ps: Callable,
     ):
         FakeYAML.serialize = MagicMock()
         FakeYAML.write = MagicMock()
@@ -446,8 +461,7 @@ class TestSubCmdAdd(BaseCommandProcessorTestSpec):
             api_path=url_path,
             http_method=method,
             parameters=params,
-            # TODO: Change to use parameter to set it
-            response_strategy=_Test_Response_Strategy,
+            response_strategy=response_strategy,
             response_value=response_value,
         )
 

--- a/test/unit_test/command/process.py
+++ b/test/unit_test/command/process.py
@@ -105,7 +105,7 @@ def _given_parser_args(
             http_method=_Test_HTTP_Method,
             parameters=[],
             response_strategy=ResponseStrategy.STRING,
-            response=_Test_HTTP_Resp,
+            response_value=_Test_HTTP_Resp,
         )
     elif subcommand == "check":
         return SubcmdCheckArguments(
@@ -441,7 +441,7 @@ class TestSubCmdAdd(BaseCommandProcessorTestSpec):
             parameters=params,
             # TODO: Change to use parameter to set it
             response_strategy=_Test_Response_Strategy,
-            response=response,
+            response_value=[response],
         )
 
         with patch("pymock_api.command.add.component.YAML", return_value=FakeYAML) as mock_instantiate_writer:
@@ -458,7 +458,7 @@ class TestSubCmdAdd(BaseCommandProcessorTestSpec):
         args_namespace.http_method = _Test_HTTP_Method
         args_namespace.parameters = ""
         args_namespace.response_strategy = _Test_Response_Strategy
-        args_namespace.response = _Test_HTTP_Resp
+        args_namespace.response_value = _Test_HTTP_Resp
         return args_namespace
 
     def _given_subcmd(self) -> Optional[str]:

--- a/test/unit_test/command/process.py
+++ b/test/unit_test/command/process.py
@@ -391,14 +391,14 @@ class TestSubCmdAdd(BaseCommandProcessorTestSpec):
     @pytest.mark.parametrize(
         ("url_path", "method", "params", "response_value"),
         [
-            ("/foo", "", [], ""),
-            ("/foo", "GET", [], ""),
-            ("/foo", "POST", [], "This is PyTest response"),
-            ("/foo", "PUT", [], "Wow testing."),
+            ("/foo", "", [], [""]),
+            ("/foo", "GET", [], [""]),
+            ("/foo", "POST", [], ["This is PyTest response"]),
+            ("/foo", "PUT", [], ["Wow testing."]),
         ],
     )
     def test_with_command_processor(
-        self, url_path: str, method: str, params: List[dict], response_value: str, object_under_test: Callable
+        self, url_path: str, method: str, params: List[dict], response_value: List[str], object_under_test: Callable
     ):
         kwargs = {
             "url_path": url_path,
@@ -412,14 +412,19 @@ class TestSubCmdAdd(BaseCommandProcessorTestSpec):
     @pytest.mark.parametrize(
         ("url_path", "method", "params", "response_value"),
         [
-            ("/foo", "", "", ""),
-            ("/foo", "GET", [], ""),
-            ("/foo", "POST", [], "This is PyTest response"),
-            ("/foo", "PUT", [], "Wow testing."),
+            ("/foo", "", "", [""]),
+            ("/foo", "GET", [], [""]),
+            ("/foo", "POST", [], ["This is PyTest response"]),
+            ("/foo", "PUT", [], ["Wow testing."]),
         ],
     )
     def test_with_run_entry_point(
-        self, url_path: str, method: str, params: List[dict], response_value: str, entry_point_under_test: Callable
+        self,
+        url_path: str,
+        method: str,
+        params: List[dict],
+        response_value: List[str],
+        entry_point_under_test: Callable,
     ):
         kwargs = {
             "url_path": url_path,
@@ -430,7 +435,9 @@ class TestSubCmdAdd(BaseCommandProcessorTestSpec):
         }
         self._test_process(**kwargs)
 
-    def _test_process(self, url_path: str, method: str, params: List[dict], response_value: str, cmd_ps: Callable):
+    def _test_process(
+        self, url_path: str, method: str, params: List[dict], response_value: List[str], cmd_ps: Callable
+    ):
         FakeYAML.serialize = MagicMock()
         FakeYAML.write = MagicMock()
         mock_parser_arg = SubcmdAddArguments(
@@ -441,7 +448,7 @@ class TestSubCmdAdd(BaseCommandProcessorTestSpec):
             parameters=params,
             # TODO: Change to use parameter to set it
             response_strategy=_Test_Response_Strategy,
-            response_value=[response_value],
+            response_value=response_value,
         )
 
         with patch("pymock_api.command.add.component.YAML", return_value=FakeYAML) as mock_instantiate_writer:

--- a/test/unit_test/command/process.py
+++ b/test/unit_test/command/process.py
@@ -395,6 +395,15 @@ class TestSubCmdAdd(BaseCommandProcessorTestSpec):
             ("/foo", "GET", [], _Test_Response_Strategy, [""]),
             ("/foo", "POST", [], _Test_Response_Strategy, ["This is PyTest response"]),
             ("/foo", "PUT", [], _Test_Response_Strategy, ["Wow testing."]),
+            ("/foo-file", "PUT", [], ResponseStrategy.FILE, [_Test_Config]),
+            (
+                "/foo-object",
+                "PUT",
+                [],
+                ResponseStrategy.OBJECT,
+                [{"name": "arg", "required": True, "type": "str", "format": None}],
+            ),
+            ("/foo-object", "PUT", [], ResponseStrategy.OBJECT, []),
         ],
     )
     def test_with_command_processor(
@@ -423,6 +432,15 @@ class TestSubCmdAdd(BaseCommandProcessorTestSpec):
             ("/foo", "GET", [], _Test_Response_Strategy, [""]),
             ("/foo", "POST", [], _Test_Response_Strategy, ["This is PyTest response"]),
             ("/foo", "PUT", [], _Test_Response_Strategy, ["Wow testing."]),
+            ("/foo-file", "PUT", [], ResponseStrategy.FILE, [_Test_Config]),
+            (
+                "/foo-object",
+                "PUT",
+                [],
+                ResponseStrategy.OBJECT,
+                [{"name": "arg", "required": True, "type": "str", "format": None}],
+            ),
+            ("/foo-object", "PUT", [], ResponseStrategy.OBJECT, []),
         ],
     )
     def test_with_run_entry_point(

--- a/test/unit_test/command/process.py
+++ b/test/unit_test/command/process.py
@@ -42,7 +42,7 @@ from pymock_api.model import (
     SubcmdSampleArguments,
     deserialize_swagger_api_config,
 )
-from pymock_api.model.enums import Format, SampleType
+from pymock_api.model.enums import Format, ResponseStrategy, SampleType
 from pymock_api.server import ASGIServer, Command, CommandOptions, WSGIServer
 
 from ..._values import (
@@ -63,6 +63,7 @@ from ..._values import (
     _Test_FastAPI_App_Type,
     _Test_HTTP_Method,
     _Test_HTTP_Resp,
+    _Test_Response_Strategy,
     _Test_SubCommand_Add,
     _Test_SubCommand_Check,
     _Test_SubCommand_Get,
@@ -103,6 +104,7 @@ def _given_parser_args(
             api_path=_Test_URL,
             http_method=_Test_HTTP_Method,
             parameters=[],
+            response_strategy=ResponseStrategy.STRING,
             response=_Test_HTTP_Resp,
         )
     elif subcommand == "check":
@@ -437,6 +439,8 @@ class TestSubCmdAdd(BaseCommandProcessorTestSpec):
             api_path=url_path,
             http_method=method,
             parameters=params,
+            # TODO: Change to use parameter to set it
+            response_strategy=_Test_Response_Strategy,
             response=response,
         )
 
@@ -453,6 +457,7 @@ class TestSubCmdAdd(BaseCommandProcessorTestSpec):
         args_namespace.api_path = _Test_URL
         args_namespace.http_method = _Test_HTTP_Method
         args_namespace.parameters = ""
+        args_namespace.response_strategy = _Test_Response_Strategy
         args_namespace.response = _Test_HTTP_Resp
         return args_namespace
 

--- a/test/unit_test/command/process.py
+++ b/test/unit_test/command/process.py
@@ -858,17 +858,34 @@ class TestSubCmdPull(BaseCommandProcessorTestSpec):
                 "pymock_api.command.pull.component.URLLibHTTPClient.request", return_value=swagger_json_data
             ) as mock_swagger_request:
                 # Run target function
+                print(f"[DEBUG in test] run target function: {cmd_ps}")
                 cmd_ps(mock_parser_arg)
 
                 mock_instantiate_writer.assert_called_once()
                 mock_swagger_request.assert_called_once_with(method="GET", url=f"http://{_API_Doc_Source}/")
 
                 # Run one core logic of target function
+                print(f"[DEBUG in test] run one core logic of target function")
+                debug_swagger_api_config = deserialize_swagger_api_config(swagger_json_data)
+                print(f"[DEBUG in test] debug_swagger_api_config: {debug_swagger_api_config}")
+                debug_api_config = debug_swagger_api_config.to_api_config(mock_parser_arg.base_url)
+                print(f"[DEBUG in test] debug_api_config: {debug_api_config}")
+                print(f"[DEBUG in test] debug_api_config.apis.apis: {debug_api_config.apis.apis}")
+                print(f"[DEBUG in test] debug_api_config.apis.apis['get_foo']: {debug_api_config.apis.apis['get_foo']}")
+                print(
+                    f"[DEBUG in test] debug_api_config.apis.apis['get_foo'].http.request: {debug_api_config.apis.apis['get_foo'].http.request}"
+                )
+                print(
+                    f"[DEBUG in test] debug_api_config.apis.apis['get_foo'].http.response: {debug_api_config.apis.apis['get_foo'].http.response}"
+                )
+                print(f"[DEBUG in test] debug_api_config.serialize(): {debug_api_config.serialize()}")
                 confirm_expected_config_data = (
                     deserialize_swagger_api_config(swagger_json_data)
                     .to_api_config(mock_parser_arg.base_url)
                     .serialize()
                 )
+                print(f"[DEBUG in test] expected_config_data: {expected_config_data}")
+                print(f"[DEBUG in test] confirm_expected_config_data: {confirm_expected_config_data}")
                 assert expected_config_data["name"] == confirm_expected_config_data["name"]
                 assert expected_config_data["description"] == confirm_expected_config_data["description"]
                 assert len(expected_config_data["mocked_apis"].keys()) == len(
@@ -881,29 +898,49 @@ class TestSubCmdPull(BaseCommandProcessorTestSpec):
                 ):
                     assert expected_key == confirm_expected_key
                     if expected_key != "base":
+                        # Verify mock API URL
                         assert (
                             expected_config_data["mocked_apis"][expected_key]["url"]
                             == confirm_expected_config_data["mocked_apis"][confirm_expected_key]["url"]
                         )
+                        # Verify mock API request properties - HTTP method
                         assert (
                             expected_config_data["mocked_apis"][expected_key]["http"]["request"]["method"]
                             == confirm_expected_config_data["mocked_apis"][confirm_expected_key]["http"]["request"][
                                 "method"
                             ]
                         )
+                        # Verify mock API request properties - request parameters
                         assert (
                             expected_config_data["mocked_apis"][expected_key]["http"]["request"]["parameters"]
                             == confirm_expected_config_data["mocked_apis"][confirm_expected_key]["http"]["request"][
                                 "parameters"
                             ]
                         )
+                        # Verify mock API response properties
                         assert (
-                            expected_config_data["mocked_apis"][expected_key]["http"]["response"]["value"]
+                            expected_config_data["mocked_apis"][expected_key]["http"]["response"]["strategy"]
                             == confirm_expected_config_data["mocked_apis"][confirm_expected_key]["http"]["response"][
-                                "value"
+                                "strategy"
                             ]
                         )
+                        assert expected_config_data["mocked_apis"][expected_key]["http"]["response"].get(
+                            "value", None
+                        ) == confirm_expected_config_data["mocked_apis"][confirm_expected_key]["http"]["response"].get(
+                            "value", None
+                        )
+                        assert expected_config_data["mocked_apis"][expected_key]["http"]["response"].get(
+                            "path", None
+                        ) == confirm_expected_config_data["mocked_apis"][confirm_expected_key]["http"]["response"].get(
+                            "path", None
+                        )
+                        assert expected_config_data["mocked_apis"][expected_key]["http"]["response"].get(
+                            "properties", None
+                        ) == confirm_expected_config_data["mocked_apis"][confirm_expected_key]["http"]["response"].get(
+                            "properties", None
+                        )
                     else:
+                        # Verify base info
                         assert (
                             expected_config_data["mocked_apis"][expected_key]
                             == confirm_expected_config_data["mocked_apis"][confirm_expected_key]

--- a/test/unit_test/command/process.py
+++ b/test/unit_test/command/process.py
@@ -389,7 +389,7 @@ class TestSubCmdAdd(BaseCommandProcessorTestSpec):
         return SubCmdAdd()
 
     @pytest.mark.parametrize(
-        ("url_path", "method", "params", "response"),
+        ("url_path", "method", "params", "response_value"),
         [
             ("/foo", "", [], ""),
             ("/foo", "GET", [], ""),
@@ -398,19 +398,19 @@ class TestSubCmdAdd(BaseCommandProcessorTestSpec):
         ],
     )
     def test_with_command_processor(
-        self, url_path: str, method: str, params: List[dict], response: str, object_under_test: Callable
+        self, url_path: str, method: str, params: List[dict], response_value: str, object_under_test: Callable
     ):
         kwargs = {
             "url_path": url_path,
             "method": method,
             "params": params,
-            "response": response,
+            "response_value": response_value,
             "cmd_ps": object_under_test,
         }
         self._test_process(**kwargs)
 
     @pytest.mark.parametrize(
-        ("url_path", "method", "params", "response"),
+        ("url_path", "method", "params", "response_value"),
         [
             ("/foo", "", "", ""),
             ("/foo", "GET", [], ""),
@@ -419,18 +419,18 @@ class TestSubCmdAdd(BaseCommandProcessorTestSpec):
         ],
     )
     def test_with_run_entry_point(
-        self, url_path: str, method: str, params: List[dict], response: str, entry_point_under_test: Callable
+        self, url_path: str, method: str, params: List[dict], response_value: str, entry_point_under_test: Callable
     ):
         kwargs = {
             "url_path": url_path,
             "method": method,
             "params": params,
-            "response": response,
+            "response_value": response_value,
             "cmd_ps": entry_point_under_test,
         }
         self._test_process(**kwargs)
 
-    def _test_process(self, url_path: str, method: str, params: List[dict], response: str, cmd_ps: Callable):
+    def _test_process(self, url_path: str, method: str, params: List[dict], response_value: str, cmd_ps: Callable):
         FakeYAML.serialize = MagicMock()
         FakeYAML.write = MagicMock()
         mock_parser_arg = SubcmdAddArguments(
@@ -441,7 +441,7 @@ class TestSubCmdAdd(BaseCommandProcessorTestSpec):
             parameters=params,
             # TODO: Change to use parameter to set it
             response_strategy=_Test_Response_Strategy,
-            response_value=[response],
+            response_value=[response_value],
         )
 
         with patch("pymock_api.command.add.component.YAML", return_value=FakeYAML) as mock_instantiate_writer:

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -34,6 +34,7 @@ from ..._values import (
     _Test_Iterable_Parameter_Items,
     _Test_Iterable_Parameter_With_MultiValue,
     _Test_Response_Properties,
+    _Test_Response_Property_List,
     _Test_Tag,
     _Test_URL,
     _TestConfig,
@@ -921,6 +922,55 @@ class TestIteratorItem(ConfigTestSpec):
         assert obj.name == _Test_Iterable_Parameter_Item_Name["name"]
         assert obj.required is _Test_Iterable_Parameter_Item_Name["required"]
         assert obj.value_type == _Test_Iterable_Parameter_Item_Name["type"]
+
+
+class TestResponseProperty(ConfigTestSpec):
+    @pytest.fixture(scope="function")
+    def sut(self) -> ResponseProperty:
+        return ResponseProperty(
+            name=_Test_Response_Property_List["name"],
+            required=_Test_Response_Property_List["required"],
+            value_type=_Test_Response_Property_List["type"],
+            value_format=_Test_Response_Property_List["format"],
+            items=_Test_Response_Property_List["items"],
+        )
+
+    @pytest.fixture(scope="function")
+    def sut_with_nothing(self) -> ResponseProperty:
+        return ResponseProperty()
+
+    def test_value_attributes(self, sut: ResponseProperty):
+        assert sut.name == _Test_Response_Property_List["name"], _assertion_msg
+        assert sut.required is _Test_Response_Property_List["required"], _assertion_msg
+        assert sut.value_type == _Test_Response_Property_List["type"], _assertion_msg
+        assert sut.value_format == _Test_Response_Property_List["format"], _assertion_msg
+        assert isinstance(sut.items, list)
+        for item in sut.items:
+            assert list(filter(lambda i: i["name"] == item.name, _Test_Response_Property_List["items"]))
+            assert list(filter(lambda i: i["required"] == item.required, _Test_Response_Property_List["items"]))
+            assert list(filter(lambda i: i["type"] == item.value_type, _Test_Response_Property_List["items"]))
+
+    def _expected_serialize_value(self) -> Any:
+        return _Test_Response_Property_List
+
+    def _expected_deserialize_value(self, obj: ResponseProperty) -> None:
+        assert isinstance(obj, ResponseProperty)
+        assert obj.name == _Test_Response_Property_List["name"]
+        assert obj.required is _Test_Response_Property_List["required"]
+        assert obj.value_type == _Test_Response_Property_List["type"]
+        assert obj.value_format == _Test_Response_Property_List["format"]
+        assert isinstance(obj.items, list)
+        for item in obj.items:
+            assert list(filter(lambda i: i["name"] == item.name, _Test_Response_Property_List["items"]))
+            assert list(filter(lambda i: i["required"] == item.required, _Test_Response_Property_List["items"]))
+            assert list(filter(lambda i: i["type"] == item.value_type, _Test_Response_Property_List["items"]))
+
+    def test_convert_invalid_items(self, sut_with_nothing: ResponseProperty):
+        with pytest.raises(TypeError) as exc_info:
+            ResponseProperty(items=["invalid element"])
+        assert re.search(
+            r".{0,32}key \*items\*.{0,32}be dict or IteratorItem.{0,32}", str(exc_info.value), re.IGNORECASE
+        )
 
 
 class TestHTTPResponseWithStringStrategy(ConfigTestSpec):

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -670,6 +670,11 @@ class TestMockAPI(ConfigTestSpec):
         assert under_test_response_value == response_value
         assert sut_with_nothing.tag == ""
 
+    def test_set_invalid_response(self, sut_with_nothing: MockAPI):
+        with pytest.raises(TypeError) as exc_info:
+            sut_with_nothing.set_response(strategy="Invalid response strategy")
+        assert re.search(r".{0,32}invalid response strategy.{0,32}", str(exc_info.value), re.IGNORECASE)
+
 
 class TestHTTP(ConfigTestSpec):
     @pytest.fixture(scope="function")

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -603,18 +603,30 @@ class TestMockAPI(ConfigTestSpec):
             sut_with_nothing.set_request(method=ut_method, parameters=ut_parameters)
         assert re.search(r".{1,64}format.{1,64}is incorrect.{1,64}", str(exc_info.value), re.IGNORECASE)
 
-    @pytest.mark.parametrize("http_resp", [None, HTTP(), HTTP(response=HTTPResponse())])
-    def test_set_response(self, http_resp: Optional[HTTPResponse], sut_with_nothing: MockAPI):
+    @pytest.mark.parametrize(
+        ("http_resp", "response_strategy", "response_value"),
+        [
+            (None, ResponseStrategy.STRING, "PyTest response"),
+            (HTTP(), ResponseStrategy.STRING, "PyTest response"),
+            (HTTP(response=HTTPResponse()), ResponseStrategy.STRING, "PyTest response"),
+        ],
+    )
+    def test_set_response(
+        self,
+        http_resp: Optional[HTTPResponse],
+        response_strategy: ResponseStrategy,
+        response_value: str,
+        sut_with_nothing: MockAPI,
+    ):
         # Pro-process
         sut_with_nothing.http = http_resp
 
         assert sut_with_nothing.http == http_resp
-        ut_value = "PyTest response"
-        sut_with_nothing.set_response(value=ut_value)
+        sut_with_nothing.set_response(strategy=response_strategy, value=response_value)
 
         assert sut_with_nothing.http
         assert sut_with_nothing.http.response
-        assert sut_with_nothing.http.response.value == ut_value
+        assert sut_with_nothing.http.response.value == response_value
         assert sut_with_nothing.tag == ""
 
 

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -993,6 +993,42 @@ class TestHTTPResponse(ConfigTestSpec):
         assert obj.value == _TestConfig.Response.get("value", None)
 
     @pytest.mark.parametrize(
+        ("compare", "be_compared"),
+        [
+            (ResponseStrategy.STRING, ResponseStrategy.FILE),
+            (ResponseStrategy.FILE, ResponseStrategy.OBJECT),
+            (ResponseStrategy.OBJECT, ResponseStrategy.STRING),
+        ],
+    )
+    def test_invalid_compare(self, compare: ResponseStrategy, be_compared: ResponseStrategy):
+        with pytest.raises(TypeError) as exc_info:
+            HTTPResponse(strategy=compare) == HTTPResponse(strategy=be_compared)
+        assert re.search(
+            r".{0,32}different HTTP response strategy.{0,32}cannot compare.{0,32}", str(exc_info.value), re.IGNORECASE
+        )
+
+    @pytest.mark.parametrize(
+        ("strategy", "expected_strategy"),
+        [
+            ("string", ResponseStrategy.STRING),
+            ("file", ResponseStrategy.FILE),
+            ("object", ResponseStrategy.OBJECT),
+        ],
+    )
+    def test_set_str_type_strategy(self, strategy: str, expected_strategy: ResponseStrategy):
+        resp = HTTPResponse(strategy=strategy)
+        assert resp.strategy is expected_strategy
+
+    def test_invalid_set_properties(self):
+        with pytest.raises(TypeError) as exc_info:
+            HTTPResponse(properties=["invalid property value"])
+        assert re.search(
+            r".{0,32}data type.{0,32}\*properties\*.{0,32}be dict or ResponseProperty.{0,32}",
+            str(exc_info.value),
+            re.IGNORECASE,
+        )
+
+    @pytest.mark.parametrize(
         "response",
         [
             HTTPResponse(strategy=ResponseStrategy.STRING),

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -19,7 +19,7 @@ from pymock_api.model.api_config import (
     MockAPIs,
     _Config,
 )
-from pymock_api.model.enums import Format
+from pymock_api.model.enums import Format, ResponseStrategy
 
 from ..._values import (
     _Base_URL,
@@ -112,7 +112,7 @@ class MockModel:
 
     @property
     def http_response(self) -> HTTPResponse:
-        return HTTPResponse(value=_Test_HTTP_Resp)
+        return HTTPResponse(strategy=ResponseStrategy.STRING, value=_Test_HTTP_Resp)
 
 
 class ConfigTestSpec(metaclass=ABCMeta):
@@ -865,14 +865,14 @@ class TestIteratorItem(ConfigTestSpec):
         assert obj.value_type == _Test_Iterable_Parameter_Item_Name["type"]
 
 
-class TestHTTPResponse(ConfigTestSpec):
+class TestHTTPResponseWithStringStrategy(ConfigTestSpec):
     @pytest.fixture(scope="function")
     def sut(self) -> HTTPResponse:
-        return HTTPResponse(value=_Test_HTTP_Resp)
+        return HTTPResponse(strategy=ResponseStrategy.STRING, value=_Test_HTTP_Resp)
 
     @pytest.fixture(scope="function")
     def sut_with_nothing(self) -> HTTPResponse:
-        return HTTPResponse()
+        return HTTPResponse(strategy=ResponseStrategy.STRING)
 
     def test_value_attributes(self, sut: HTTPResponse):
         assert sut.value == _Test_HTTP_Resp, _assertion_msg

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -1027,3 +1027,31 @@ class TestHTTPResponse(ConfigTestSpec):
     )
     def test_serialize_with_strategy(self, response: HTTPResponse, expected_data: dict):
         assert response.serialize() == expected_data
+
+    @pytest.mark.parametrize(
+        ("data", "expected_response"),
+        [
+            (
+                {"strategy": ResponseStrategy.STRING.value, "value": "OK"},
+                HTTPResponse(strategy=ResponseStrategy.STRING, value="OK"),
+            ),
+            (
+                {"strategy": ResponseStrategy.FILE.value, "path": "file path"},
+                HTTPResponse(strategy=ResponseStrategy.FILE, path="file path"),
+            ),
+            (
+                {
+                    "strategy": ResponseStrategy.OBJECT.value,
+                    "properties": [p.serialize() for p in MockModel().response_properties],
+                },
+                HTTPResponse(strategy=ResponseStrategy.OBJECT, properties=MockModel().response_properties),
+            ),
+        ],
+    )
+    def test_valid_deserialize_with_strategy(self, data: dict, expected_response: HTTPResponse):
+        assert HTTPResponse().deserialize(data=data) == expected_response
+
+    def test_invalid_deserialize_with_strategy(self):
+        with pytest.raises(ValueError) as exc_info:
+            HTTPResponse().deserialize(data={"miss strategy": ""})
+        assert re.search(r".{0,32}strategy.{0,32}cannot be empty.{0,32}", str(exc_info.value), re.IGNORECASE)

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -1,3 +1,4 @@
+import random
 import re
 from abc import ABCMeta, abstractmethod
 from typing import Any, Dict, List, Optional, Union
@@ -1012,6 +1013,21 @@ class TestHTTPResponse(ConfigTestSpec):
     @pytest.mark.parametrize(
         ("compare", "be_compared"),
         [
+            (None, random.choice([s for s in ResponseStrategy])),
+            (None, None),
+        ],
+    )
+    def test_invalid_compare_with_missing_strategy(self, compare: ResponseStrategy, be_compared: ResponseStrategy):
+        with pytest.raises(ValueError) as exc_info:
+            HTTPResponse(strategy=compare) == HTTPResponse(strategy=be_compared)
+        assert re.search(r".{0,32}Miss.{0,32}strategy.{0,32}", str(exc_info.value), re.IGNORECASE)
+
+    @pytest.mark.parametrize(
+        ("compare", "be_compared"),
+        [
+            (ResponseStrategy.STRING, None),
+            (ResponseStrategy.FILE, None),
+            (ResponseStrategy.OBJECT, None),
             (ResponseStrategy.STRING, ResponseStrategy.FILE),
             (ResponseStrategy.FILE, ResponseStrategy.OBJECT),
             (ResponseStrategy.OBJECT, ResponseStrategy.STRING),

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -640,7 +640,7 @@ class TestMockAPI(ConfigTestSpec):
             (HTTP(response=HTTPResponse()), ResponseStrategy.OBJECT, _Test_Response_Properties),
         ],
     )
-    def test_set_response(
+    def test_set_valid_response(
         self,
         http_resp: Optional[HTTPResponse],
         response_strategy: ResponseStrategy,

--- a/test/unit_test/model/cmd_args.py
+++ b/test/unit_test/model/cmd_args.py
@@ -32,6 +32,7 @@ from ..._values import (
     _Test_Config,
     _Test_HTTP_Method,
     _Test_HTTP_Resp,
+    _Test_Response_Strategy,
     _Test_SubCommand_Add,
     _Test_SubCommand_Check,
     _Test_SubCommand_Get,
@@ -77,6 +78,7 @@ class TestDeserialize:
             "api_path": _Test_URL,
             "http_method": _Test_HTTP_Method,
             "parameters": ['{"name": "arg1", "required": false, "default": "val1", "type": "str"}'],
+            "response_strategy": _Test_Response_Strategy,
             "response": _Test_HTTP_Resp,
         }
         namespace = Namespace(**namespace_args)

--- a/test/unit_test/model/cmd_args.py
+++ b/test/unit_test/model/cmd_args.py
@@ -79,7 +79,7 @@ class TestDeserialize:
             "http_method": _Test_HTTP_Method,
             "parameters": ['{"name": "arg1", "required": false, "default": "val1", "type": "str"}'],
             "response_strategy": _Test_Response_Strategy,
-            "response": _Test_HTTP_Resp,
+            "response_value": [_Test_HTTP_Resp],
         }
         namespace = Namespace(**namespace_args)
         arguments = deserialize.subcommand_add(namespace)
@@ -89,7 +89,7 @@ class TestDeserialize:
         assert arguments.api_path == _Test_URL
         assert arguments.http_method == _Test_HTTP_Method
         assert arguments.parameters == [{"name": "arg1", "required": False, "default": "val1", "type": "str"}]
-        assert arguments.response == _Test_HTTP_Resp
+        assert arguments.response_value == [_Test_HTTP_Resp]
 
     @pytest.mark.parametrize(
         (

--- a/test/unit_test/model/swagger_config.py
+++ b/test/unit_test/model/swagger_config.py
@@ -189,6 +189,12 @@ class TestAPI(_SwaggerDataModelTestSuite):
         set_component_definition(data=entire_swagger_config, key="definitions")
         super().test_deserialize(swagger_api_doc_data, data_model)
 
+    def test_invalid_deserialize(self, data_model: API):
+        data_model.process_response_strategy = None
+        with pytest.raises(ValueError) as exc_info:
+            data_model.deserialize(data={})
+        assert re.search(r".{0,32}strategy.{0,32}", str(exc_info.value), re.IGNORECASE)
+
     def _initial(self, data: API) -> None:
         data.path = ""
         data.http_method = ""

--- a/test/unit_test/model/swagger_config.py
+++ b/test/unit_test/model/swagger_config.py
@@ -11,6 +11,7 @@ import pytest
 from pymock_api.model.api_config import APIConfig
 from pymock_api.model.api_config import APIParameter as PyMockAPIParameter
 from pymock_api.model.api_config import MockAPI, _Config
+from pymock_api.model.enums import ResponseStrategy
 from pymock_api.model.swagger_config import (
     API,
     APIParameter,
@@ -206,7 +207,7 @@ class TestAPI(_SwaggerDataModelTestSuite):
         data_model.path = "/test/v1/foo-home"
         data_model.http_method = "POST"
         data_model.parameters = [params]
-        data_model.response = {}
+        data_model.response = {"strategy": ResponseStrategy.STRING, "data": "OK"}
         data_model.tags = ["first tag", "second tag"]
 
     def _verify_api_config_model(self, under_test: MockAPI, data_from: API) -> None:
@@ -314,7 +315,7 @@ class TestSwaggerConfig(_SwaggerDataModelTestSuite):
         api.path = "/test/v1/foo-home"
         api.http_method = "POST"
         api.parameters = [params]
-        api.response = {}
+        api.response = {"strategy": ResponseStrategy.STRING, "data": "OK"}
 
         data_model.paths = [api]
 
@@ -340,7 +341,8 @@ class TestSwaggerConfig(_SwaggerDataModelTestSuite):
                 assert api_param.required == param_data_from.required
                 assert api_param.value_type == param_data_from.value_type
                 assert api_param.default == param_data_from.default
-            assert api_details.http.response.value == json.dumps(expect_api.response)
+            assert api_details.http.response.strategy == expect_api.response["strategy"]
+            assert api_details.http.response.value == expect_api.response["data"]
 
     @pytest.mark.parametrize(
         ("base_url", "api_path"),

--- a/test/unit_test/server/application/init.py
+++ b/test/unit_test/server/application/init.py
@@ -15,12 +15,6 @@ from pymock_api.server.application import BaseAppServer, FastAPIServer, FlaskSer
 
 MockerModule = namedtuple("MockerModule", ["module_path", "return_value"])
 
-_General_String_Value: str = "This is test message for PyTest."
-_Json_File_Name: str = "test.json"
-_Json_File_Content: dict = {"responseCode": "200", "errorMessage": "OK", "content": "This is YouTube home."}
-_Not_Exist_File_Name: str = "not_exist.json"
-_Not_Json_File_Name: str = "test.yaml"
-
 
 class FakeFlask(Flask):
     pass

--- a/test/unit_test/server/application/response.py
+++ b/test/unit_test/server/application/response.py
@@ -1,13 +1,6 @@
 import json
 import os
 from pydoc import locate
-from test.unit_test.server.application.init import (
-    _General_String_Value,
-    _Json_File_Content,
-    _Json_File_Name,
-    _Not_Exist_File_Name,
-    _Not_Json_File_Name,
-)
 from typing import Type
 from unittest.mock import mock_open, patch
 
@@ -18,7 +11,15 @@ from pymock_api.model import HTTPResponse
 from pymock_api.model.enums import ResponseStrategy
 from pymock_api.server.application.response import HTTPResponse as _HTTPResponse
 
-from ...._values import _HTTP_Response_Properties_With_Object_Strategy
+from ...._values import (
+    _General_String_Value,
+    _HTTP_Response_Properties_With_Object_Strategy,
+    _Json_File_Content,
+    _Json_File_Name,
+    _Not_Exist_File_Name,
+    _Not_Json_File_Name,
+    _Unexpected_File_Name,
+)
 
 
 class _MockHTTPResponse:
@@ -42,6 +43,10 @@ class _MockHTTPResponse:
     @staticmethod
     def with_not_json_file_strategy() -> HTTPResponse:
         return HTTPResponse(strategy=ResponseStrategy.FILE, path=_Not_Json_File_Name)
+
+    @staticmethod
+    def with_unexpected_file_strategy() -> HTTPResponse:
+        return HTTPResponse(strategy=ResponseStrategy.FILE, path=_Unexpected_File_Name)
 
     @staticmethod
     def with_object_strategy() -> HTTPResponse:
@@ -93,6 +98,14 @@ class TestInnerHTTPResponse:
                 expected_err_msg = f"It doesn't support reading '{', '.join(http_resp.valid_file_format)}' format file."
                 assert str(exc_info) == expected_err_msg, f"The error message should be same as '{expected_err_msg}'."
                 mock_file_stream.assert_not_called()
+
+    def test_response_with_unexpected_file_name(self, http_resp: Type[_HTTPResponse]):
+        with patch("builtins.open", mock_open(read_data=None)) as mock_file_stream:
+            # Run target function to test
+            response = http_resp.generate(data=_MockHTTPResponse.with_unexpected_file_strategy())
+            # Verify result
+            assert response == _Unexpected_File_Name
+            mock_file_stream.assert_not_called()
 
     def test_response_with_object(self, http_resp: Type[_HTTPResponse]):
         resp_data = http_resp.generate(data=_MockHTTPResponse.with_object_strategy())

--- a/test/unit_test/server/application/response.py
+++ b/test/unit_test/server/application/response.py
@@ -1,8 +1,9 @@
 import json
 import os
+import re
 from pydoc import locate
 from typing import Type
-from unittest.mock import mock_open, patch
+from unittest.mock import Mock, mock_open, patch
 
 import pytest
 
@@ -51,6 +52,12 @@ class _MockHTTPResponse:
     @staticmethod
     def with_object_strategy() -> HTTPResponse:
         return HTTPResponse(strategy=ResponseStrategy.OBJECT, properties=_HTTP_Response_Properties_With_Object_Strategy)
+
+    @staticmethod
+    def with_invalid_strategy() -> HTTPResponse:
+        http_response = Mock()
+        http_response.strategy = "invalid strategy"
+        return http_response
 
 
 class TestInnerHTTPResponse:
@@ -147,3 +154,8 @@ class TestInnerHTTPResponse:
                             assert False, "Invalid data type of response for verifying."
             else:
                 assert False, "Invalid data type of response for verifying."
+
+    def test_response_with_invalid_strategy(self, http_resp: Type[_HTTPResponse]):
+        with pytest.raises(TypeError) as exc_info:
+            http_resp.generate(data=_MockHTTPResponse.with_invalid_strategy())
+        assert re.search(r".{0,32}invalid.{0,32}", str(exc_info.value), re.IGNORECASE)


### PR DESCRIPTION
### _Target_

* Support configure HTTP response with different strategy as API response.
* Example usage and its response: 
    - Response strategy: String
        ```yaml
        # Configuration
        response:
          strategy: string
          value: "this is string type API response"
        ```
        ```console
        # API response
        this is string type API response
        ```

    - Response strategy: File
        ```yaml
        # Configuration
        response:
          strategy: file
          value: api_response.json
        ```
        ```json
        // This is the content of file *api_response.json*
        {
          "error_msg": "",
          "resp_value": [0, 1, 2, 3]
        }
        ```
        ```json
        // API response which is the content of the file
        {
          "error_msg": "",
          "resp_value": [0, 1, 2, 3]
        }
        ```

    - Response strategy: Object
        ```yaml
        # Configuration
        response:
          strategy: object
          properties:
            - name: code
              required: True
              type: int
            - name: description
              required: True
              type: str
            - name: value
              required: True
              type: list
              items:
                - name: argument
                  required: True
                  type: str
                - name: value
                  required: True
                  type: str
        ```
        ```json
        // API response
        {
          "code": 200,
          "description": "this is API response which be generate by object type response strategy",
          "value": [
            {"argument": "arg_1", "value": "val_10"},
            {"argument": "arg_2", "value": "val_20"},
            {"argument": "arg_3", "value": "val_30"}
          ]
        }
        ```


### _Effecting Scope_

* The syntax of **_PyMock-API_** configuration and providing new feature of HTTP response.


### _Description_

* Add more data model or modify existing data model properties for new feature of HTTP response.
    * **ResponseProperty** (new)
    * **HTTPResponse** (modify)
* Support configuring HTTP response with different strategy in **_PyMock-API_** configuration.
    * strategy options: _string_, _file_ and _object_.
* Support pulling HTTP response with different strategy of API configuration, e.g., Swagger format, as **_PyMock-API_** configuration.
* Add more tests includes unit test and integration test for new feature of HTTP response.
