### PR TITLE
🎉🎊🍾 [New Feature] Add new section *template* data model and new properties about dividing configuration.

### DIFF
--- a/pymock_api/command/pull/component.py
+++ b/pymock_api/command/pull/component.py
@@ -15,6 +15,8 @@ class SubCmdPullComponent(BaseSubCmdComponent):
         swagger_api_doc = self._get_swagger_config(swagger_url=f"http://{args.source}/")
         api_config = swagger_api_doc.to_api_config(base_url=args.base_url)
         print("Write the API configuration to file ...")
+        # TODO: Add command line option to control this setting
+        api_config.set_template_in_config = False
         self._file.write(path=args.config_path, config=api_config.serialize())
         print(f"All configuration has been writen in file '{args.config_path}'.")
 

--- a/pymock_api/model/api_config.py
+++ b/pymock_api/model/api_config.py
@@ -65,6 +65,11 @@ class _Config(metaclass=ABCMeta):
 class _TemplatableConfig(_Config, ABC):
     apply_template_props: bool = True
 
+    # The settings which could be set by section *template* or override the values
+    base_file_path: str = "./"
+    config_path: str = field(default_factory=str)
+    config_path_format: str = field(default_factory=str)
+
     _has_apply_template_props_in_config: bool = False
 
     def _compare(self, other: SelfType) -> bool:

--- a/pymock_api/model/api_config.py
+++ b/pymock_api/model/api_config.py
@@ -163,6 +163,32 @@ class TemplateResponse(TemplateSetting):
 
 
 @dataclass(eq=False)
+class TemplateValues(_Config):
+    api: TemplateAPI = TemplateAPI()
+    request: TemplateRequest = TemplateRequest()
+    response: TemplateResponse = TemplateResponse()
+
+    def _compare(self, other: "TemplateValues") -> bool:
+        return self.api is other.api and self.request == other.request and self.response == other.response
+
+    def serialize(self, data: Optional["TemplateValues"] = None) -> Optional[Dict[str, Any]]:
+        api = self.api or self._get_prop(data, prop="api")
+        request = self.request or self._get_prop(data, prop="request")
+        response = self.response or self._get_prop(data, prop="response")
+        if not (api and request and response):
+            # TODO: Should raise exception?
+            return None
+        return {"api": api.serialize(), "request": request.serialize(), "response": response.serialize()}
+
+    @_Config._ensure_process_with_not_empty_value
+    def deserialize(self, data: Dict[str, Any]) -> Optional["TemplateValues"]:
+        self.api = TemplateAPI().deserialize(data.get("api", {}))
+        self.request = TemplateRequest().deserialize(data.get("request", {}))
+        self.response = TemplateResponse().deserialize(data.get("response", {}))
+        return self
+
+
+@dataclass(eq=False)
 class TemplateApply(_Config):
     scan_strategy: Optional[TemplateApplyScanStrategy] = None
     api: List[Union[str, Dict[str, List[str]]]] = field(default_factory=list)
@@ -187,32 +213,6 @@ class TemplateApply(_Config):
     def deserialize(self, data: Dict[str, Any]) -> Optional["TemplateApply"]:
         self.scan_strategy = TemplateApplyScanStrategy.to_enum(data.get("scan_strategy", None))
         self.api = data.get("api")  # type: ignore[assignment]
-        return self
-
-
-@dataclass(eq=False)
-class TemplateValues(_Config):
-    api: TemplateAPI = TemplateAPI()
-    request: TemplateRequest = TemplateRequest()
-    response: TemplateResponse = TemplateResponse()
-
-    def _compare(self, other: "TemplateValues") -> bool:
-        return self.api is other.api and self.request == other.request and self.response == other.response
-
-    def serialize(self, data: Optional["TemplateValues"] = None) -> Optional[Dict[str, Any]]:
-        api = self.api or self._get_prop(data, prop="api")
-        request = self.request or self._get_prop(data, prop="request")
-        response = self.response or self._get_prop(data, prop="response")
-        if not (api and request and response):
-            # TODO: Should raise exception?
-            return None
-        return {"api": api.serialize(), "request": request.serialize(), "response": response.serialize()}
-
-    @_Config._ensure_process_with_not_empty_value
-    def deserialize(self, data: Dict[str, Any]) -> Optional["TemplateValues"]:
-        self.api = TemplateAPI().deserialize(data.get("api", {}))
-        self.request = TemplateRequest().deserialize(data.get("request", {}))
-        self.response = TemplateResponse().deserialize(data.get("response", {}))
         return self
 
 

--- a/pymock_api/model/api_config.py
+++ b/pymock_api/model/api_config.py
@@ -224,11 +224,15 @@ class TemplateApply(_Config):
         return self.scan_strategy is other.scan_strategy and self.api == other.api
 
     def serialize(self, data: Optional["TemplateApply"] = None) -> Optional[Dict[str, Any]]:
-        scan_strategy: TemplateApplyScanStrategy = TemplateApplyScanStrategy.to_enum(
-            self.scan_strategy or self._get_prop(data, prop="scan_strategy")
+        scan_strategy: TemplateApplyScanStrategy = self.scan_strategy or TemplateApplyScanStrategy.to_enum(
+            self._get_prop(data, prop="scan_strategy")
         )
         if not scan_strategy:
             raise ValueError("Necessary argument *scan_strategy* is missing.")
+        if not isinstance(scan_strategy, TemplateApplyScanStrategy):
+            raise TypeError(
+                "Argument *scan_strategy* data type is invalid. It only accepts *TemplateApplyScanStrategy* type value."
+            )
 
         api: str = self._get_prop(data, prop="api")
         return {
@@ -239,6 +243,8 @@ class TemplateApply(_Config):
     @_Config._ensure_process_with_not_empty_value
     def deserialize(self, data: Dict[str, Any]) -> Optional["TemplateApply"]:
         self.scan_strategy = TemplateApplyScanStrategy.to_enum(data.get("scan_strategy", None))
+        if not self.scan_strategy:
+            raise ValueError("Schema key *scan_strategy* cannot be empty.")
         self.api = data.get("api")  # type: ignore[assignment]
         return self
 
@@ -548,6 +554,8 @@ class HTTPResponse(_TemplatableConfig):
         strategy: ResponseStrategy = self.strategy or ResponseStrategy.to_enum(self._get_prop(data, prop="strategy"))
         if not strategy:
             raise ValueError("Necessary argument *strategy* is missing.")
+        if not isinstance(strategy, ResponseStrategy):
+            raise TypeError("Argument *strategy* data type is invalid. It only accepts *ResponseStrategy* type value.")
         if strategy is ResponseStrategy.STRING:
             value: str = self._get_prop(data, prop="value")
             serialized_data.update(

--- a/pymock_api/model/api_config.py
+++ b/pymock_api/model/api_config.py
@@ -191,6 +191,32 @@ class TemplateApply(_Config):
 
 
 @dataclass(eq=False)
+class TemplateValues(_Config):
+    api: TemplateAPI = TemplateAPI()
+    request: TemplateRequest = TemplateRequest()
+    response: TemplateResponse = TemplateResponse()
+
+    def _compare(self, other: "TemplateValues") -> bool:
+        return self.api is other.api and self.request == other.request and self.response == other.response
+
+    def serialize(self, data: Optional["TemplateValues"] = None) -> Optional[Dict[str, Any]]:
+        api = self.api or self._get_prop(data, prop="api")
+        request = self.request or self._get_prop(data, prop="request")
+        response = self.response or self._get_prop(data, prop="response")
+        if not (api and request and response):
+            # TODO: Should raise exception?
+            return None
+        return {"api": api.serialize(), "request": request.serialize(), "response": response.serialize()}
+
+    @_Config._ensure_process_with_not_empty_value
+    def deserialize(self, data: Dict[str, Any]) -> Optional["TemplateValues"]:
+        self.api = TemplateAPI().deserialize(data.get("api", {}))
+        self.request = TemplateRequest().deserialize(data.get("request", {}))
+        self.response = TemplateResponse().deserialize(data.get("response", {}))
+        return self
+
+
+@dataclass(eq=False)
 class IteratorItem(_Config):
     name: str = field(default_factory=str)
     required: Optional[bool] = None

--- a/pymock_api/model/api_config.py
+++ b/pymock_api/model/api_config.py
@@ -2,7 +2,7 @@
 
 content ...
 """
-from abc import ABCMeta, abstractmethod
+from abc import ABC, ABCMeta, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -102,6 +102,38 @@ class BaseConfig(_Config):
         """
         self.url = data.get("url", None)
         return self
+
+
+@dataclass(eq=False)
+class TemplateSetting(_Config, ABC):
+    base_file_path: str = "./"
+    config_path: str = field(default_factory=str)
+    config_path_format: str = field(default_factory=str)
+
+    def _compare(self, other: "TemplateSetting") -> bool:
+        return (
+            self.base_file_path == other.base_file_path
+            and self.config_path == other.config_path
+            and self.config_path_format == other.config_path_format
+        )
+
+    def serialize(self, data: Optional["TemplateSetting"] = None) -> Optional[Dict[str, Any]]:
+        return {
+            "base_file_path": self.base_file_path,
+            "config_path": self.config_path,
+            "config_path_format": self.config_path_format,
+        }
+
+    def deserialize(self, data: Dict[str, Any]) -> Optional["TemplateSetting"]:
+        self.base_file_path = data.get("config_path_format", "./")
+        self.config_path = data.get("config_path", "")
+        self.config_path_format = data.get("config_path_format", self._default_config_path_format)
+        return self
+
+    @property
+    @abstractmethod
+    def _default_config_path_format(self) -> str:
+        pass
 
 
 @dataclass(eq=False)

--- a/pymock_api/model/enums.py
+++ b/pymock_api/model/enums.py
@@ -26,3 +26,17 @@ class ResponseStrategy(Enum):
             return ResponseStrategy(v.lower())
         else:
             return v
+
+
+class TemplateApplyScanStrategy(Enum):
+    BY_FILE_NAME: str = "by_file_name"
+    BY_CONFIG_LIST: str = "by_config_list"
+    FILE_NAME_FIRST: str = "file_name_first"
+    CONFIG_LIST_FIRST: str = "config_list_first"
+
+    @staticmethod
+    def to_enum(v: Union[str, "TemplateApplyScanStrategy"]) -> "TemplateApplyScanStrategy":
+        if isinstance(v, str):
+            return TemplateApplyScanStrategy(v.lower())
+        else:
+            return v

--- a/test/_values.py
+++ b/test/_values.py
@@ -81,6 +81,10 @@ _Mock_Template_Setting: dict = {
     "apply": _Mock_Template_Apply_Has_Tag_Setting,
 }
 
+_Mock_Templatable_Setting: dict = {
+    "apply_template_props": False,
+}
+
 
 # Sample item of iterator
 _Test_Iterable_Parameter_Item_Name: dict = {

--- a/test/_values.py
+++ b/test/_values.py
@@ -49,10 +49,14 @@ _Mock_Template_API_Setting: dict = generate_mock_template()
 _Mock_Template_API_Request_Setting: dict = generate_mock_template("request")
 _Mock_Template_API_Response_Setting: dict = generate_mock_template("response")
 
-_Mock_Template_Setting: dict = {
+_Mock_Template_Values_Setting: dict = {
     "api": _Mock_Template_API_Setting,
     "request": _Mock_Template_API_Request_Setting,
     "response": _Mock_Template_API_Response_Setting,
+}
+
+_Mock_Template_Setting: dict = {
+    "values": _Mock_Template_Values_Setting,
 }
 
 _Mock_Template_Apply_Has_Tag_Setting: dict = {

--- a/test/_values.py
+++ b/test/_values.py
@@ -34,6 +34,27 @@ _Mock_API_HTTP: dict = {
     "response": Mock,
 }
 
+
+def generate_mock_template(tail_naming: str = "") -> dict:
+    return {
+        "base_file_path": "./",
+        "config_path": "",
+        "config_path_format": "{{ api.tag }}/{{ api.__name__ }}.yaml"
+        if not tail_naming
+        else ("{{ api.tag }}/{{ api.__name__ }}" + f"-{tail_naming}" + ".yaml"),
+    }
+
+
+_Mock_Template_API_Setting: dict = generate_mock_template()
+_Mock_Template_API_Request_Setting: dict = generate_mock_template("request")
+_Mock_Template_API_Response_Setting: dict = generate_mock_template("response")
+
+_Mock_Template_Setting: dict = {
+    "api": _Mock_Template_API_Setting,
+    "request": _Mock_Template_API_Request_Setting,
+    "response": _Mock_Template_API_Response_Setting,
+}
+
 # Sample item of iterator
 _Test_Iterable_Parameter_Item_Name: dict = {
     "name": "name",
@@ -288,6 +309,7 @@ _Foo_Object_Value: dict = {
 
 
 _Mocked_APIs: dict = {
+    "template": _Mock_Template_Setting,
     "base": {"url": _Base_URL},
     "apis": {
         "google_home": _Google_Home_Value,
@@ -317,7 +339,13 @@ class _TestConfig:
     Http: dict = {"request": Request, "response": Response}
     Mock_API: dict = {"url": _Test_URL, "http": Http, "tag": _Test_Tag}
     Base: dict = {"url": _Base_URL}
-    Mock_APIs: dict = {"base": Base, "apis": {"test_config": Mock_API}}
+    Mock_APIs: dict = {
+        "template": _Mock_Template_Setting,
+        "base": Base,
+        "apis": {
+            "test_config": Mock_API,
+        },
+    }
     API_Config: dict = {
         "name": _Config_Name,
         "description": _Config_Description,

--- a/test/_values.py
+++ b/test/_values.py
@@ -55,10 +55,6 @@ _Mock_Template_Values_Setting: dict = {
     "response": _Mock_Template_API_Response_Setting,
 }
 
-_Mock_Template_Setting: dict = {
-    "values": _Mock_Template_Values_Setting,
-}
-
 _Mock_Template_Apply_Has_Tag_Setting: dict = {
     "scan_strategy": "file_name_first",
     "api": [
@@ -78,6 +74,12 @@ def generate_template_apply(scan_strategy: str, api: List) -> dict:
         "scan_strategy": scan_strategy,
         "api": api,
     }
+
+
+_Mock_Template_Setting: dict = {
+    "values": _Mock_Template_Values_Setting,
+    "apply": _Mock_Template_Apply_Has_Tag_Setting,
+}
 
 
 # Sample item of iterator

--- a/test/_values.py
+++ b/test/_values.py
@@ -55,6 +55,27 @@ _Mock_Template_Setting: dict = {
     "response": _Mock_Template_API_Response_Setting,
 }
 
+_Mock_Template_Apply_Has_Tag_Setting: dict = {
+    "scan_strategy": "file_name_first",
+    "api": [
+        {"foo": ["get_foo", "put_foo"]},
+        {"foo-boo": ["get_foo-boo_export"]},
+    ],
+}
+
+_Mock_Template_Apply_No_Tag_Setting: dict = {
+    "scan_strategy": "file_name_first",
+    "api": ["get_foo", "put_foo"],
+}
+
+
+def generate_template_apply(scan_strategy: str, api: List) -> dict:
+    return {
+        "scan_strategy": scan_strategy,
+        "api": api,
+    }
+
+
 # Sample item of iterator
 _Test_Iterable_Parameter_Item_Name: dict = {
     "name": "name",

--- a/test/_values.py
+++ b/test/_values.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from typing import Dict, List
 from unittest.mock import Mock
 
-from pymock_api.model.enums import ResponseStrategy
+from pymock_api.model.enums import ResponseStrategy, TemplateApplyScanStrategy
 
 
 class APIConfigValue:
@@ -55,8 +55,10 @@ _Mock_Template_Values_Setting: dict = {
     "response": _Mock_Template_API_Response_Setting,
 }
 
+_Mock_Template_Apply_Scan_Strategy: TemplateApplyScanStrategy = TemplateApplyScanStrategy.FILE_NAME_FIRST
+
 _Mock_Template_Apply_Has_Tag_Setting: dict = {
-    "scan_strategy": "file_name_first",
+    "scan_strategy": _Mock_Template_Apply_Scan_Strategy.value,
     "api": [
         {"foo": ["get_foo", "put_foo"]},
         {"foo-boo": ["get_foo-boo_export"]},
@@ -64,7 +66,7 @@ _Mock_Template_Apply_Has_Tag_Setting: dict = {
 }
 
 _Mock_Template_Apply_No_Tag_Setting: dict = {
-    "scan_strategy": "file_name_first",
+    "scan_strategy": _Mock_Template_Apply_Scan_Strategy.value,
     "api": ["get_foo", "put_foo"],
 }
 

--- a/test/data/divide_test/has-base-info_and_tags_test/api.yaml
+++ b/test/data/divide_test/has-base-info_and_tags_test/api.yaml
@@ -2,18 +2,19 @@ name: ''
 description: ''
 mocked_apis:
   template:    # Optional
-    api:
-      base_file_path: './'    # Default value should be current path './'
-      config_path:    # Default value should be None or empty string
-      config_path_format: '{{ api.tag }}/{{ api.__name__ }}.yaml'    # ex. ./foo/get_foo.yaml
-    request:
-      base_file_path: './'
-      config_path:
-      config_path_format: '{{ api.tag }}/{{ api.__name__ }}-request.yaml'
-    response:
-      base_file_path: './'
-      config_path:
-      config_path_format: '{{ api.tag }}/{{ api.__name__ }}-response.yaml'
+    values:
+      api:
+        base_file_path: './'    # Default value should be current path './'
+        config_path:    # Default value should be None or empty string
+        config_path_format: '{{ api.tag }}/{{ api.__name__ }}.yaml'    # ex. ./foo/get_foo.yaml
+      request:
+        base_file_path: './'
+        config_path:
+        config_path_format: '{{ api.tag }}/{{ api.__name__ }}-request.yaml'
+      response:
+        base_file_path: './'
+        config_path:
+        config_path_format: '{{ api.tag }}/{{ api.__name__ }}-response.yaml'
     apply:    # Which mocked APIs should apply template values
       # Have 4 different strategy for scanning files to load configuration:
       # 1. by_file_name: auto-use the format to find satisfied file naming to configure

--- a/test/data/divide_test/has-base-info_test/api.yaml
+++ b/test/data/divide_test/has-base-info_test/api.yaml
@@ -2,18 +2,19 @@ name: ''
 description: ''
 mocked_apis:
   template:
-    api:
-      base_file_path: './'
-      config_path:
-      config_path_format: '{{ api.tag }}/{{ api.__name__ }}.yaml'
-    request:
-      base_file_path: './'
-      config_path:
-      config_path_format: '{{ api.tag }}/{{ api.__name__ }}-request.yaml'
-    response:
-      base_file_path: './'
-      config_path:
-      config_path_format: '{{ api.tag }}/{{ api.__name__ }}-response.yaml'
+    values:
+      api:
+        base_file_path: './'
+        config_path:
+        config_path_format: '{{ api.tag }}/{{ api.__name__ }}.yaml'
+      request:
+        base_file_path: './'
+        config_path:
+        config_path_format: '{{ api.tag }}/{{ api.__name__ }}-request.yaml'
+      response:
+        base_file_path: './'
+        config_path:
+        config_path_format: '{{ api.tag }}/{{ api.__name__ }}-response.yaml'
     apply:
       scan_strategy: file_name_first
       api:

--- a/test/data/divide_test/no-base-info_test/api.yaml
+++ b/test/data/divide_test/no-base-info_test/api.yaml
@@ -2,18 +2,19 @@ name: ''
 description: ''
 mocked_apis:
   template:
-    api:
-      base_file_path: './'
-      config_path:
-      config_path_format: '{{ api.tag }}/{{ api.__name__ }}.yaml'
-    request:
-      base_file_path: './'
-      config_path:
-      config_path_format: '{{ api.tag }}/{{ api.__name__ }}-request.yaml'
-    response:
-      base_file_path: './'
-      config_path:
-      config_path_format: '{{ api.tag }}/{{ api.__name__ }}-response.yaml'
+    values:
+      api:
+        base_file_path: './'
+        config_path:
+        config_path_format: '{{ api.tag }}/{{ api.__name__ }}.yaml'
+      request:
+        base_file_path: './'
+        config_path:
+        config_path_format: '{{ api.tag }}/{{ api.__name__ }}-request.yaml'
+      response:
+        base_file_path: './'
+        config_path:
+        config_path_format: '{{ api.tag }}/{{ api.__name__ }}-response.yaml'
     apply:
       scan_strategy: file_name_first
       api:

--- a/test/unit_test/command/process.py
+++ b/test/unit_test/command/process.py
@@ -910,24 +910,11 @@ class TestSubCmdPull(BaseCommandProcessorTestSpec):
 
                 # Run one core logic of target function
                 print(f"[DEBUG in test] run one core logic of target function")
-                debug_swagger_api_config = deserialize_swagger_api_config(swagger_json_data)
-                print(f"[DEBUG in test] debug_swagger_api_config: {debug_swagger_api_config}")
-                debug_api_config = debug_swagger_api_config.to_api_config(mock_parser_arg.base_url)
-                print(f"[DEBUG in test] debug_api_config: {debug_api_config}")
-                print(f"[DEBUG in test] debug_api_config.apis.apis: {debug_api_config.apis.apis}")
-                print(f"[DEBUG in test] debug_api_config.apis.apis['get_foo']: {debug_api_config.apis.apis['get_foo']}")
-                print(
-                    f"[DEBUG in test] debug_api_config.apis.apis['get_foo'].http.request: {debug_api_config.apis.apis['get_foo'].http.request}"
+                confirm_expected_api_config = deserialize_swagger_api_config(swagger_json_data).to_api_config(
+                    mock_parser_arg.base_url
                 )
-                print(
-                    f"[DEBUG in test] debug_api_config.apis.apis['get_foo'].http.response: {debug_api_config.apis.apis['get_foo'].http.response}"
-                )
-                print(f"[DEBUG in test] debug_api_config.serialize(): {debug_api_config.serialize()}")
-                confirm_expected_config_data = (
-                    deserialize_swagger_api_config(swagger_json_data)
-                    .to_api_config(mock_parser_arg.base_url)
-                    .serialize()
-                )
+                confirm_expected_api_config.set_template_in_config = False
+                confirm_expected_config_data = confirm_expected_api_config.serialize()
                 print(f"[DEBUG in test] expected_config_data: {expected_config_data}")
                 print(f"[DEBUG in test] confirm_expected_config_data: {confirm_expected_config_data}")
                 assert expected_config_data["name"] == confirm_expected_config_data["name"]

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -736,6 +736,12 @@ class TestTemplateApply(ConfigTestSpec):
         assert obj.scan_strategy.value == _Mock_Template_Apply_Has_Tag_Setting.get("scan_strategy")
         assert obj.api == _Mock_Template_Apply_Has_Tag_Setting.get("api")
 
+    def test_serialize_with_invalid_scan_strategy(self, sut_with_nothing: TemplateApply):
+        with pytest.raises(ValueError) as exc_info:
+            sut_with_nothing.scan_strategy = "invalid strategy"
+            sut_with_nothing.serialize()
+        assert re.search(r"", str(exc_info.value), re.IGNORECASE)
+
 
 class TestTemplateConfig(ConfigTestSpec):
     @pytest.fixture(scope="function")

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -579,37 +579,6 @@ class TestTemplateResponse(TemplateSettingTestSuite):
         return TemplateResponse
 
 
-class TestTemplateApply(ConfigTestSpec):
-    @pytest.fixture(scope="function")
-    def sut(self) -> TemplateApply:
-        return TemplateApply(
-            scan_strategy=_Mock_Template_Apply_Has_Tag_Setting.get("scan_strategy"),
-            api=_Mock_Template_Apply_Has_Tag_Setting.get("api"),
-        )
-
-    @pytest.fixture(scope="function")
-    def sut_with_nothing(self) -> TemplateApply:
-        return TemplateApply(scan_strategy=_Mock_Template_Apply_Has_Tag_Setting.get("scan_strategy"))
-
-    def test_value_attributes(self, sut: TemplateApply):
-        assert sut.scan_strategy == _Mock_Template_Apply_Has_Tag_Setting.get("scan_strategy")
-        assert sut.api == _Mock_Template_Apply_Has_Tag_Setting.get("api")
-
-    def test_serialize_with_none(self, sut_with_nothing: TemplateApply):
-        serialized_data = sut_with_nothing.serialize()
-        assert serialized_data is not None
-        assert serialized_data["scan_strategy"] == _Mock_Template_Apply_Has_Tag_Setting.get("scan_strategy")
-        assert serialized_data["api"] == []
-
-    def _expected_serialize_value(self) -> dict:
-        return _Mock_Template_Apply_Has_Tag_Setting
-
-    def _expected_deserialize_value(self, obj: TemplateApply) -> None:
-        assert isinstance(obj, TemplateApply)
-        assert obj.scan_strategy.value == _Mock_Template_Apply_Has_Tag_Setting.get("scan_strategy")
-        assert obj.api == _Mock_Template_Apply_Has_Tag_Setting.get("api")
-
-
 class TestTemplateValues(ConfigTestSpec):
     @pytest.fixture(scope="function")
     def sut(self) -> TemplateValues:
@@ -642,6 +611,37 @@ class TestTemplateValues(ConfigTestSpec):
         assert obj.api.serialize() == _Mock_Template_Values_Setting.get("api")
         assert obj.request.serialize() == _Mock_Template_Values_Setting.get("request")
         assert obj.response.serialize() == _Mock_Template_Values_Setting.get("response")
+
+
+class TestTemplateApply(ConfigTestSpec):
+    @pytest.fixture(scope="function")
+    def sut(self) -> TemplateApply:
+        return TemplateApply(
+            scan_strategy=_Mock_Template_Apply_Has_Tag_Setting.get("scan_strategy"),
+            api=_Mock_Template_Apply_Has_Tag_Setting.get("api"),
+        )
+
+    @pytest.fixture(scope="function")
+    def sut_with_nothing(self) -> TemplateApply:
+        return TemplateApply(scan_strategy=_Mock_Template_Apply_Has_Tag_Setting.get("scan_strategy"))
+
+    def test_value_attributes(self, sut: TemplateApply):
+        assert sut.scan_strategy == _Mock_Template_Apply_Has_Tag_Setting.get("scan_strategy")
+        assert sut.api == _Mock_Template_Apply_Has_Tag_Setting.get("api")
+
+    def test_serialize_with_none(self, sut_with_nothing: TemplateApply):
+        serialized_data = sut_with_nothing.serialize()
+        assert serialized_data is not None
+        assert serialized_data["scan_strategy"] == _Mock_Template_Apply_Has_Tag_Setting.get("scan_strategy")
+        assert serialized_data["api"] == []
+
+    def _expected_serialize_value(self) -> dict:
+        return _Mock_Template_Apply_Has_Tag_Setting
+
+    def _expected_deserialize_value(self, obj: TemplateApply) -> None:
+        assert isinstance(obj, TemplateApply)
+        assert obj.scan_strategy.value == _Mock_Template_Apply_Has_Tag_Setting.get("scan_strategy")
+        assert obj.api == _Mock_Template_Apply_Has_Tag_Setting.get("api")
 
 
 class TestMockAPI(ConfigTestSpec):

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -20,6 +20,7 @@ from pymock_api.model.api_config import (
     MockAPIs,
     ResponseProperty,
     TemplateAPI,
+    TemplateApply,
     TemplateRequest,
     TemplateResponse,
     TemplateSetting,
@@ -34,6 +35,7 @@ from ..._values import (
     _Mock_Template_API_Request_Setting,
     _Mock_Template_API_Response_Setting,
     _Mock_Template_API_Setting,
+    _Mock_Template_Apply_Has_Tag_Setting,
     _Test_API_Parameter,
     _Test_Config,
     _Test_HTTP_Resp,
@@ -555,6 +557,37 @@ class TestTemplateResponse(TemplateSettingTestSuite):
     @property
     def sut_object(self) -> Type[TemplateSetting]:
         return TemplateResponse
+
+
+class TestTemplateApply(ConfigTestSpec):
+    @pytest.fixture(scope="function")
+    def sut(self) -> TemplateApply:
+        return TemplateApply(
+            scan_strategy=_Mock_Template_Apply_Has_Tag_Setting.get("scan_strategy"),
+            api=_Mock_Template_Apply_Has_Tag_Setting.get("api"),
+        )
+
+    @pytest.fixture(scope="function")
+    def sut_with_nothing(self) -> TemplateApply:
+        return TemplateApply(scan_strategy=_Mock_Template_Apply_Has_Tag_Setting.get("scan_strategy"))
+
+    def test_value_attributes(self, sut: TemplateApply):
+        assert sut.scan_strategy == _Mock_Template_Apply_Has_Tag_Setting.get("scan_strategy")
+        assert sut.api == _Mock_Template_Apply_Has_Tag_Setting.get("api")
+
+    def test_serialize_with_none(self, sut_with_nothing: TemplateApply):
+        serialized_data = sut_with_nothing.serialize()
+        assert serialized_data is not None
+        assert serialized_data["scan_strategy"] == _Mock_Template_Apply_Has_Tag_Setting.get("scan_strategy")
+        assert serialized_data["api"] == []
+
+    def _expected_serialize_value(self) -> dict:
+        return _Mock_Template_Apply_Has_Tag_Setting
+
+    def _expected_deserialize_value(self, obj: TemplateApply) -> None:
+        assert isinstance(obj, TemplateApply)
+        assert obj.scan_strategy.value == _Mock_Template_Apply_Has_Tag_Setting.get("scan_strategy")
+        assert obj.api == _Mock_Template_Apply_Has_Tag_Setting.get("api")
 
 
 class TestMockAPI(ConfigTestSpec):

--- a/test/unit_test/model/api_config.py
+++ b/test/unit_test/model/api_config.py
@@ -24,6 +24,7 @@ from pymock_api.model.api_config import (
     TemplateRequest,
     TemplateResponse,
     TemplateSetting,
+    TemplateValues,
     _Config,
 )
 from pymock_api.model.enums import Format, ResponseStrategy
@@ -36,6 +37,7 @@ from ..._values import (
     _Mock_Template_API_Response_Setting,
     _Mock_Template_API_Setting,
     _Mock_Template_Apply_Has_Tag_Setting,
+    _Mock_Template_Values_Setting,
     _Test_API_Parameter,
     _Test_Config,
     _Test_HTTP_Resp,
@@ -96,6 +98,24 @@ class MockModel:
     @property
     def mock_apis(self) -> MockAPIs:
         return MockAPIs(base=self.base_config, apis=self.mock_api)
+
+    @property
+    def template_values_api(self) -> TemplateAPI:
+        return TemplateAPI()
+
+    @property
+    def template_values_request(self) -> TemplateRequest:
+        return TemplateRequest()
+
+    @property
+    def template_values_response(self) -> TemplateResponse:
+        return TemplateResponse()
+
+    @property
+    def template_values(self) -> TemplateValues:
+        return TemplateValues(
+            api=self.template_values_api, request=self.template_values_request, response=self.template_values_response
+        )
 
     @property
     def base_config(self) -> BaseConfig:
@@ -588,6 +608,40 @@ class TestTemplateApply(ConfigTestSpec):
         assert isinstance(obj, TemplateApply)
         assert obj.scan_strategy.value == _Mock_Template_Apply_Has_Tag_Setting.get("scan_strategy")
         assert obj.api == _Mock_Template_Apply_Has_Tag_Setting.get("api")
+
+
+class TestTemplateValues(ConfigTestSpec):
+    @pytest.fixture(scope="function")
+    def sut(self) -> TemplateValues:
+        return TemplateValues(
+            api=MOCK_MODEL.template_values_api,
+            request=MOCK_MODEL.template_values_request,
+            response=MOCK_MODEL.template_values_response,
+        )
+
+    @pytest.fixture(scope="function")
+    def sut_with_nothing(self) -> TemplateValues:
+        return TemplateValues()
+
+    def test_value_attributes(self, sut: TemplateValues):
+        assert sut.api == MOCK_MODEL.template_values_api
+        assert sut.request == MOCK_MODEL.template_values_request
+        assert sut.response == MOCK_MODEL.template_values_response
+
+    def test_serialize_with_none(self, sut_with_nothing: TemplateValues):
+        sut_with_nothing.api = None
+        sut_with_nothing.request = None
+        sut_with_nothing.response = None
+        super().test_serialize_with_none(sut_with_nothing)
+
+    def _expected_serialize_value(self) -> dict:
+        return _Mock_Template_Values_Setting
+
+    def _expected_deserialize_value(self, obj: TemplateValues) -> None:
+        assert isinstance(obj, TemplateValues)
+        assert obj.api.serialize() == _Mock_Template_Values_Setting.get("api")
+        assert obj.request.serialize() == _Mock_Template_Values_Setting.get("request")
+        assert obj.response.serialize() == _Mock_Template_Values_Setting.get("response")
 
 
 class TestMockAPI(ConfigTestSpec):


### PR DESCRIPTION
### _Target_

* Add new section *template* data model and new properties about dividing configuration.
* Tickets: 
    * Properties about dividing configuration: [MOCKAPI-33](https://chisanan232.atlassian.net/browse/MOCKAPI-33)
    * New section *template* data model: [MOCKAPI-37](https://chisanan232.atlassian.net/browse/MOCKAPI-37)
* Example config:
    ```yaml
    name: ''
    description: ''
    mocked_apis:
      template:    # Optional
        values:
          api:
            base_file_path: './'    # Default value should be current path './'
            config_path:    # Default value should be None or empty string
            config_path_format: '{{ api.tag }}/{{ api.__name__ }}.yaml'    # ex. ./foo/get_foo.yaml
          request:
            base_file_path: './'
            config_path:
            config_path_format: '{{ api.tag }}/{{ api.__name__ }}-request.yaml'
          response:
            base_file_path: './'
            config_path:
            config_path_format: '{{ api.tag }}/{{ api.__name__ }}-response.yaml'
        apply:    # Which mocked APIs should apply template values
          # Have 4 different strategy for scanning files to load configuration:
          # 1. by_file_name: auto-use the format to find satisfied file naming to configure
          # 2. by_config_list: only use the list in config to find the satisfied file naming
          # 3. file_name_first: it would find the file naming by strategy *by_file_name* way. If it cannot find it, it would find it again by strategy *by_config_list*.
          # 4. config_list_first: it would find the file naming by strategy *by_config_list* way. If it cannot find it, it would find it again by strategy *by_file_name*.
          scan_strategy: file_name_first    # Default value is *file_name_first*
          api:    # Which mocked APIs should apply template values to its entire settings includes URL, request and response
            - foo:    # If it has tag, it could set the tag name as key and set the target APIs as list type value of the key
              - get_foo
              - put_foo
            - foo-boo:
              - get_foo-boo_export
      base:
        url: '/api/v1/test'
      put_foo:
        apply_template_props: False
        url: /foo
        http:
          apply_template_props: False
          request:
            apply_template_props: True
            base_file_path: './tmp'
          response:
            apply_template_props: True
    ```


### _Effecting Scope_

* Nothing, this new feature supports downward compatibility. But it provides new section, aka its data model for using.


### _Description_

* Add new section *template* and its data models:
    * **TemplateConfig**
        * **TemplateValues**
            * **TemplateAPI**
            * **TemplateRequest**
            * **TemplateResponse**
        * **TemplateApply**
* Add new property **_apply_template_props_** at the sections which support using template properties.
    * **MockAPI**
        * **HTTP**
            * **HTTPRequest**
            * **HTTPResponse**


[MOCKAPI-33]: https://chisanan232.atlassian.net/browse/MOCKAPI-33?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOCKAPI-37]: https://chisanan232.atlassian.net/browse/MOCKAPI-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ