### PR TITLE
🎉🎊🍾 [New Feature] Add new template section *http* for mocked API section *http*.

### DIFF
--- a/pymock_api/model/api_config/apis/__init__.py
+++ b/pymock_api/model/api_config/apis/__init__.py
@@ -120,10 +120,6 @@ class HTTP(_TemplatableConfig):
 
         super().deserialize(data)
 
-        # FIXME: Extract the running process order as a single function
-        if self.apply_template_props:
-            data = self._get_dividing_config(data)
-
         req = data.get("request", None)
         resp = data.get("response", None)
         self.request = _deserialize_data_model(HTTPRequest, req)  # type: ignore[assignment]
@@ -255,10 +251,6 @@ class MockAPI(_TemplatableConfig):
                 return None
 
         super().deserialize(data)
-
-        # FIXME: Extract the running process order as a single function
-        if self.apply_template_props:
-            data = self._get_dividing_config(data)
 
         self.url = data.get("url", None)
         http_info = data.get("http", None)

--- a/pymock_api/model/api_config/apis/__init__.py
+++ b/pymock_api/model/api_config/apis/__init__.py
@@ -119,6 +119,11 @@ class HTTP(_TemplatableConfig):
                 return None
 
         super().deserialize(data)
+
+        # FIXME: Extract the running process order as a single function
+        if self.apply_template_props:
+            data = self._get_dividing_config(data)
+
         req = data.get("request", None)
         resp = data.get("response", None)
         self.request = _deserialize_data_model(HTTPRequest, req)  # type: ignore[assignment]

--- a/pymock_api/model/api_config/apis/request.py
+++ b/pymock_api/model/api_config/apis/request.py
@@ -129,10 +129,6 @@ class HTTPRequest(_TemplatableConfig):
         """
         super().deserialize(data)
 
-        # FIXME: Extract the running process order as a single function
-        if self.apply_template_props:
-            data = self._get_dividing_config(data)
-
         self.method = data.get("method", None)
         parameters: List[dict] = data.get("parameters", None)
         if parameters and not isinstance(parameters, list):

--- a/pymock_api/model/api_config/apis/response.py
+++ b/pymock_api/model/api_config/apis/response.py
@@ -184,10 +184,6 @@ class HTTPResponse(_TemplatableConfig):
         """
         super().deserialize(data)
 
-        # FIXME: Extract the running process order as a single function
-        if self.apply_template_props:
-            data = self._get_dividing_config(data)
-
         self.strategy = ResponseStrategy.to_enum(data.get("strategy", None))
         if not self.strategy:
             raise ValueError("Schema key *strategy* cannot be empty.")

--- a/pymock_api/model/api_config/template.py
+++ b/pymock_api/model/api_config/template.py
@@ -46,6 +46,12 @@ class TemplateAPI(TemplateSetting):
         return "**-api.yaml"
 
 
+class TemplateHTTP(TemplateSetting):
+    @property
+    def _default_config_path_format(self) -> str:
+        return "**-http.yaml"
+
+
 class TemplateRequest(TemplateSetting):
     @property
     def _default_config_path_format(self) -> str:
@@ -62,6 +68,7 @@ class TemplateResponse(TemplateSetting):
 class TemplateValues(_Config):
     base_file_path: str = "./"
     api: TemplateAPI = TemplateAPI()
+    http: TemplateHTTP = TemplateHTTP()
     request: TemplateRequest = TemplateRequest()
     response: TemplateResponse = TemplateResponse()
 
@@ -69,6 +76,7 @@ class TemplateValues(_Config):
         return (
             self.base_file_path == other.base_file_path
             and self.api == other.api
+            and self.http == other.http
             and self.request == other.request
             and self.response == other.response
         )
@@ -76,6 +84,7 @@ class TemplateValues(_Config):
     def serialize(self, data: Optional["TemplateValues"] = None) -> Optional[Dict[str, Any]]:
         base_file_path: str = self._get_prop(data, prop="base_file_path")
         api = self.api or self._get_prop(data, prop="api")
+        http = self.http or self._get_prop(data, prop="http")
         request = self.request or self._get_prop(data, prop="request")
         response = self.response or self._get_prop(data, prop="response")
         if not (api and request and response):
@@ -84,6 +93,7 @@ class TemplateValues(_Config):
         return {
             "base_file_path": base_file_path,
             "api": api.serialize(),
+            "http": http.serialize(),
             "request": request.serialize(),
             "response": response.serialize(),
         }
@@ -92,6 +102,7 @@ class TemplateValues(_Config):
     def deserialize(self, data: Dict[str, Any]) -> Optional["TemplateValues"]:
         self.base_file_path = data.get("base_file_path", "./")
         self.api = TemplateAPI().deserialize(data.get("api", {}))
+        self.http = TemplateHTTP().deserialize(data.get("http", {}))
         self.request = TemplateRequest().deserialize(data.get("request", {}))
         self.response = TemplateResponse().deserialize(data.get("response", {}))
         return self

--- a/pymock_api/model/api_config/template.py
+++ b/pymock_api/model/api_config/template.py
@@ -302,6 +302,10 @@ class _TemplatableConfig(_Config, ABC):
         _update_template_prop("base_file_path")
         _update_template_prop("config_path")
         _update_template_prop("config_path_format")
+
+        # FIXME: Extract the running process order as a single function
+        if self.apply_template_props:
+            data = self._get_dividing_config(data)
         return self
 
     def _get_dividing_config(self, data: dict) -> dict:

--- a/test/_values.py
+++ b/test/_values.py
@@ -43,12 +43,14 @@ def generate_mock_template(tail_naming: str = "") -> dict:
 
 _Mock_Base_File_Path: str = "./"
 _Mock_Template_API_Setting: dict = generate_mock_template("api")
+_Mock_Template_HTTP_Setting: dict = generate_mock_template("http")
 _Mock_Template_API_Request_Setting: dict = generate_mock_template("request")
 _Mock_Template_API_Response_Setting: dict = generate_mock_template("response")
 
 _Mock_Template_Values_Setting: dict = {
     "base_file_path": _Mock_Base_File_Path,
     "api": _Mock_Template_API_Setting,
+    "http": _Mock_Template_HTTP_Setting,
     "request": _Mock_Template_API_Request_Setting,
     "response": _Mock_Template_API_Response_Setting,
 }

--- a/test/data/divide_test/has-base-info_and_tags_has_mocked_apis_with_divide_http_test/api.yaml
+++ b/test/data/divide_test/has-base-info_and_tags_has_mocked_apis_with_divide_http_test/api.yaml
@@ -8,6 +8,8 @@ mocked_apis:
       base_file_path: './test/data/divide_test/has-base-info_and_tags_has_mocked_apis_with_divide_http_test/'    # Default value should be current path './'
       api:
         config_path_format: '**-api'    # ex. ./foo/get_foo.yaml
+      http:
+        config_path_format: '**-http'
       request:
         config_path_format: '**-request'
       response:

--- a/test/data/divide_test/has-base-info_and_tags_has_mocked_apis_with_divide_http_test/foo/put_foo-api.yaml
+++ b/test/data/divide_test/has-base-info_and_tags_has_mocked_apis_with_divide_http_test/foo/put_foo-api.yaml
@@ -1,32 +1,6 @@
 url: '/foo'
 http:
-  request:
-    method: 'PUT'
-    parameters:
-      - name: 'balances'
-        required: true
-        default:
-        type: list
-        format:
-        items:
-          - required: true
-            type: int
-            name: "value"
-          - required: true
-            type: int
-            name: "id"
-  response:
-    strategy: object
-    properties:
-      - name: errorMessage
-        required: True
-        type: str
-        format:
-      - name: responseCode
-        required: True
-        type: str
-        format:
-      - name: responseData
-        required: False
-        type: list
-        format:
+  apply_template_props: True
+  base_file_path: './test/data/divide_test/has-base-info_and_tags_has_mocked_apis_with_divide_http_test/foo'
+  config_path:
+  config_path_format: '**-http'

--- a/test/data/divide_test/has-base-info_and_tags_has_mocked_apis_with_divide_http_test/foo/put_foo-http.yaml
+++ b/test/data/divide_test/has-base-info_and_tags_has_mocked_apis_with_divide_http_test/foo/put_foo-http.yaml
@@ -1,0 +1,30 @@
+request:
+  method: 'PUT'
+  parameters:
+    - name: 'balances'
+      required: true
+      default:
+      type: list
+      format:
+      items:
+        - required: true
+          type: int
+          name: "value"
+        - required: true
+          type: int
+          name: "id"
+response:
+  strategy: object
+  properties:
+    - name: errorMessage
+      required: True
+      type: str
+      format:
+    - name: responseCode
+      required: True
+      type: str
+      format:
+    - name: responseData
+      required: False
+      type: list
+      format:

--- a/test/data/divide_test/has-base-info_and_tags_no_mocked_apis_with_divide_http_test/api.yaml
+++ b/test/data/divide_test/has-base-info_and_tags_no_mocked_apis_with_divide_http_test/api.yaml
@@ -8,6 +8,8 @@ mocked_apis:
       base_file_path: './test/data/divide_test/has-base-info_and_tags_no_mocked_apis_with_divide_http_test/'    # Default value should be current path './'
       api:
         config_path_format: '**-api'    # ex. ./foo/get_foo.yaml
+      http:
+        config_path_format: '**-http'
       request:
         config_path_format: '**-request'
       response:

--- a/test/data/divide_test/has-base-info_and_tags_test/api.yaml
+++ b/test/data/divide_test/has-base-info_and_tags_test/api.yaml
@@ -8,6 +8,8 @@ mocked_apis:
       base_file_path: './test/data/divide_test/has-base-info_and_tags_test/'    # Default value should be current path './'
       api:
         config_path_format: '**-api'    # ex. ./foo/get_foo.yaml
+      http:
+        config_path_format: '**-http'
       request:
         config_path_format: '**-request'
       response:

--- a/test/data/divide_test/has-base-info_divide_http_test/api.yaml
+++ b/test/data/divide_test/has-base-info_divide_http_test/api.yaml
@@ -8,6 +8,8 @@ mocked_apis:
       base_file_path: './test/data/divide_test/has-base-info_divide_http_test/'
       api:
         config_path_format: '**-api'
+      http:
+        config_path_format: '**-http'
       request:
         config_path_format: '**-request'
       response:

--- a/test/data/divide_test/has-base-info_test/api.yaml
+++ b/test/data/divide_test/has-base-info_test/api.yaml
@@ -8,6 +8,8 @@ mocked_apis:
       base_file_path: './test/data/divide_test/has-base-info_test/'
       api:
         config_path_format: '**-api'
+      http:
+        config_path_format: '**-http'
       request:
         config_path_format: '**-request'
       response:

--- a/test/data/divide_test/no-base-info_test/api.yaml
+++ b/test/data/divide_test/no-base-info_test/api.yaml
@@ -8,6 +8,8 @@ mocked_apis:
       base_file_path: './test/data/divide_test/no-base-info_test/'
       api:
         config_path_format: '**-api'
+      http:
+        config_path_format: '**-http'
       request:
         config_path_format: '**-request'
       response:

--- a/test/unit_test/model/api_config/template.py
+++ b/test/unit_test/model/api_config/template.py
@@ -8,6 +8,7 @@ from pymock_api.model.api_config import TemplateConfig, _Config, _TemplatableCon
 from pymock_api.model.api_config.template import (
     TemplateAPI,
     TemplateApply,
+    TemplateHTTP,
     TemplateRequest,
     TemplateResponse,
     TemplateSetting,
@@ -23,6 +24,7 @@ from ...._values import (
     _Mock_Template_Apply_Has_Tag_Setting,
     _Mock_Template_Apply_Scan_Strategy,
     _Mock_Template_Config_Activate,
+    _Mock_Template_HTTP_Setting,
     _Mock_Template_Setting,
     _Mock_Template_Values_Setting,
 )
@@ -109,6 +111,16 @@ class TestTemplateAPI(TemplateSettingTestSuite):
     @property
     def sut_object(self) -> Type[TemplateSetting]:
         return TemplateAPI
+
+
+class TestTemplateHTTP(TemplateSettingTestSuite):
+    @property
+    def under_test_data(self) -> dict:
+        return _Mock_Template_HTTP_Setting
+
+    @property
+    def sut_object(self) -> Type[TemplateHTTP]:
+        return TemplateHTTP
 
 
 class TestTemplateRequest(TemplateSettingTestSuite):


### PR DESCRIPTION
### _Target_

* Add new template section _http_ for mocked API section _http_.


### _Effecting Scope_

* No any breaking change.


### _Description_

* Add new data model about template of section ``mocked_apis.apis.<api>.http``.
* Implement the dividing configuration feature at section ``mocked_apis.apis.<api>.http``.

