### PR TITLE
🤖⚙️🔧 [Improvement] Modify the CI process running condition.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
   all-test_codecov:
 #    name: Organize and generate the testing report and upload it to Codecov
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: [run_unit-test, run_integration-test]
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/organize_and_generate_test_cov_reports.yaml@v4
     with:


### PR DESCRIPTION
### _Target_

* Modify the CI process running condition.


### _Effecting Scope_

* The CI workflow would keep running recording test coverage report process if the git branch is **_master_** and the git event is _push_.


### _Description_

* Modify the running condition of process about recording test coverage report, SonarQube scan, etc.
