### PR TITLE
🤖⚙️🔧 [Improvement] Let CI process only runs at key point git event.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,27 @@ on:
     branches:
       - "master"
       - "develop/**"
+    paths-ignore:
+#     For GitHub dependency bot
+      - ".github/dependabot.yaml"
+#     For documentation
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/workflows/documentation.yaml"
+      - "docs/**"
+      - "**/*.md"
+      - "mkdocs.yml"
+      - "README.md"
+#     For Docker feature
+      - ".github/workflows/docker.yaml"
+      - "scripts/ci/**-docker-**.sh"
+      - "scripts/docker/**"
+      - "Dockerfile"
+      - "README-DOCKER.md"
+#     Others
+      - ".gitcommitrules"
+      - ".gitignore"
+      - ".pre-commit-config.yaml"
+      - ".pylintrc"
 
   # For the pull request event, it sniffs branch 'develop/**', 'release' and 'master' and make sure anything would be
   # fine without any issue before review and merge.


### PR DESCRIPTION
### _Target_

* Let CI process only runs at key point git event.


### _Effecting Scope_

* The condition for triggering CI process.


### _Description_

* ➕ Add setting about CI process should ignore some files or directory change.
