### PR TITLE
[🛠🐛💣 Bug Fix] Fix the incorrect badge image URL about testing code coverage in documentation home page.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@
     <img src="https://github.com/Chisanan232/PyMock-API/actions/workflows/ci-cd.yml/badge.svg" alt="CI/CD status">
   </a>
   <a href="https://codecov.io/gh/Chisanan232/PyMock-API">
-    <img src="https://codecov.io/gh/Chisanan232/PyMock-API/branch/main/graph/badge.svg?token=r5HJxg9KhN" alt="Test coverage">
+    <img src="https://codecov.io/gh/Chisanan232/PyMock-API/graph/badge.svg?token=r5HJxg9KhN" alt="Test coverage">
   </a>
   <a href="https://results.pre-commit.ci/latest/github/Chisanan232/PyMock-API/master">
     <img src="https://results.pre-commit.ci/badge/github/Chisanan232/PyMock-API/master.svg" alt="Pre-Commit building state">


### PR DESCRIPTION
### _Target_

* Fix the incorrect badge image URL about testing code coverage in documentation home page.


### _Effecting Scope_

* Let the badge could display normally.


### _Description_

* Modify the badge image URL as correct.
    * AS-IS
    <img width="805" alt="Screenshot 2024-03-13 at 5 49 12 PM" src="https://github.com/Chisanan232/PyMock-API/assets/42397554/d2d91444-71a0-4486-82b5-9678497d0231">

    * TO-BE
    <img width="879" alt="Screenshot 2024-03-13 at 5 49 16 PM" src="https://github.com/Chisanan232/PyMock-API/assets/42397554/8d704de6-284e-4d4c-9e53-dfe5aec80287">
