### PR TITLE
🤖⚙️🔧 [Improvement] Divide the test code coverage reports to 4 types to clear the state of project testing with different ways. 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,48 @@ jobs:
     uses: ./.github/workflows/rw_build_and_test.yaml
 
 
+  unit-test_codecov_finish:
+#    name: Organize and generate the testing report and upload it to Codecov
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
+    needs: build-and-test
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_upload_test_cov_report.yaml@v5
+    secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}
+    with:
+      test_type: unit-test
+      upload-to-codecov: true
+      codecov_flags: unit-test  # Required if 'upload-to-codecov' is true
+      codecov_name: pymock-api  # Required if 'upload-to-codecov' is true
+
+
+  integration-test_codecov_finish:
+#    name: Organize and generate the testing report and upload it to Codecov
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
+    needs: build-and-test
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_upload_test_cov_report.yaml@v5
+    secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}
+    with:
+      test_type: all-test
+      upload-to-codecov: true
+      codecov_flags: integration-test  # Required if 'upload-to-codecov' is true
+      codecov_name: pymock-api  # Required if 'upload-to-codecov' is true
+
+
+  system-test_codecov_finish:
+#    name: Organize and generate the testing report and upload it to Codecov
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
+    needs: build-and-test
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_upload_test_cov_report.yaml@v5
+    secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}
+    with:
+      test_type: all-test
+      upload-to-codecov: true
+      codecov_flags: system-test  # Required if 'upload-to-codecov' is true
+      codecov_name: pymock-api  # Required if 'upload-to-codecov' is true
+
+
   all-test_codecov_finish:
 #    name: Organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
@@ -74,7 +116,7 @@ jobs:
     with:
       test_type: all-test
       upload-to-codecov: true
-      codecov_flags: unit,integration,system  # Required if 'upload-to-codecov' is true
+      codecov_flags: all-test  # Required if 'upload-to-codecov' is true
       codecov_name: pymock-api  # Required if 'upload-to-codecov' is true
 
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
     uses: ./.github/workflows/rw_build_and_test.yaml
 
 
-  codecov_finish:
+  all-test_codecov_finish:
 #    name: Organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: build-and-test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,7 +133,7 @@ jobs:
 
   pre-building_test:
 #    name: Check about it could work finely by installing the Python package with setup.py file
-    needs: [codecov_finish, sonarcloud_finish]
+    needs: [unit-test_codecov_finish, integration-test_codecov_finish, system-test_codecov_finish, all-test_codecov_finish, sonarcloud_finish]
     if: ${{ github.ref_name == 'release' || github.ref_name == 'master' }}
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_pre-building_test.yaml@v5
     with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,7 +96,7 @@ jobs:
 #    name: Organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: build-and-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_upload_test_cov_report.yaml@v5
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_upload_test_cov_report.yaml@develop
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
     with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,7 +86,7 @@ jobs:
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
     with:
-      test_type: all-test
+      test_type: integration-test
       upload-to-codecov: true
       codecov_flags: integration-test  # Required if 'upload-to-codecov' is true
       codecov_name: pymock-api  # Required if 'upload-to-codecov' is true
@@ -100,7 +100,7 @@ jobs:
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
     with:
-      test_type: all-test
+      test_type: system-test
       upload-to-codecov: true
       codecov_flags: system-test  # Required if 'upload-to-codecov' is true
       codecov_name: pymock-api  # Required if 'upload-to-codecov' is true

--- a/.github/workflows/rw_build_and_test.yaml
+++ b/.github/workflows/rw_build_and_test.yaml
@@ -52,6 +52,33 @@ jobs:
       all_test_items_paths: ${{needs.prep_system-test.outputs.all_test_items}}
 
 
+  unit-test_codecov:
+#    name: For unit test, organize and generate the testing report and upload it to Codecov
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
+    needs: run_unit-test
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v5
+    with:
+      test_type: unit-test
+
+
+  integration-test_codecov:
+#    name: For unit test, organize and generate the testing report and upload it to Codecov
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
+    needs: run_integration-test
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v5
+    with:
+      test_type: integration-test
+
+
+  system-test_codecov:
+#    name: For unit test, organize and generate the testing report and upload it to Codecov
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
+    needs: run_system-test
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v5
+    with:
+      test_type: system-test
+
+
   all_test_codecov:
 #    name: Organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}


### PR DESCRIPTION
### _Target_

* Divide the test code coverage reports to 4 types to clear the state of project testing with different ways.


### _Effecting Scope_

* Nothing, just divide the test code coverage reports.


### _Description_

* Add CI process for organizing the test code coverage reports with different test types.
* Add CI process for uploading the test code coverage reports to **_CodeCov_** with different flags.
