### PR TITLE
🔬🧪🧬 [Refactor] Extract all logic about OpenAPI documentation parsing as abstractions.

### DIFF
--- a/pymock_api/command/check/component.py
+++ b/pymock_api/command/check/component.py
@@ -6,8 +6,8 @@ from typing import Any, Optional
 from ... import APIConfig
 from ..._utils.api_client import URLLibHTTPClient
 from ...model import (
+    OpenAPIDocumentConfig,
     SubcmdCheckArguments,
-    SwaggerConfig,
     deserialize_swagger_api_config,
     load_config,
 )
@@ -217,7 +217,7 @@ class SwaggerDiffChecking(_BaseChecking):
 
         return api_config
 
-    def _get_swagger_config(self, swagger_url: str) -> SwaggerConfig:
+    def _get_swagger_config(self, swagger_url: str) -> OpenAPIDocumentConfig:
         swagger_api_doc: dict = self._api_client.request(method="GET", url=swagger_url)
         return deserialize_swagger_api_config(data=swagger_api_doc)
 

--- a/pymock_api/command/pull/component.py
+++ b/pymock_api/command/pull/component.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, Optional
 
 from ..._utils import YAML
 from ..._utils.api_client import URLLibHTTPClient
-from ...model import SwaggerConfig, deserialize_swagger_api_config
+from ...model import OpenAPIDocumentConfig, deserialize_swagger_api_config
 from ...model.api_config import APIConfig, DivideStrategy
 from ...model.cmd_args import SubcmdPullArguments
 from ..component import BaseSubCmdComponent
@@ -25,7 +25,7 @@ class SubCmdPullComponent(BaseSubCmdComponent):
         else:
             self._final_process(args, serialized_api_config)
 
-    def _get_swagger_config(self, swagger_url: str) -> SwaggerConfig:
+    def _get_swagger_config(self, swagger_url: str) -> OpenAPIDocumentConfig:
         swagger_api_doc: dict = self._api_client.request(method="GET", url=swagger_url)
         return deserialize_swagger_api_config(data=swagger_api_doc)
 

--- a/pymock_api/model/__init__.py
+++ b/pymock_api/model/__init__.py
@@ -21,7 +21,7 @@ from .cmd_args import (
     SubcmdRunArguments,
     SubcmdSampleArguments,
 )
-from .openapi.config import SwaggerConfig
+from .openapi.config import OpenAPIDocumentConfig
 
 
 class deserialize_args:
@@ -104,8 +104,8 @@ class deserialize_args:
         return DeserializeParsedArgs.subcommand_pull(args)
 
 
-def deserialize_swagger_api_config(data: dict) -> SwaggerConfig:
-    return SwaggerConfig().deserialize(data=data)
+def deserialize_swagger_api_config(data: dict) -> OpenAPIDocumentConfig:
+    return OpenAPIDocumentConfig().deserialize(data=data)
 
 
 def load_config(path: str, is_pull: bool = False, base_file_path: str = "") -> Optional[APIConfig]:

--- a/pymock_api/model/openapi/_parse.py
+++ b/pymock_api/model/openapi/_parse.py
@@ -1,12 +1,24 @@
 import json
 import pathlib
+from abc import ABCMeta, abstractmethod
 from typing import Any, Dict, List, Optional
 
 
-class OpenAPIObjectParser:
+class BaseOpenAPIObjectParser(metaclass=ABCMeta):
 
     def __init__(self, data: dict):
         self._data = data
+
+    @abstractmethod
+    def get_required(self, default: Any = None) -> List[str]:
+        pass
+
+    @abstractmethod
+    def get_properties(self, default: Any = None) -> Dict[str, dict]:
+        pass
+
+
+class OpenAPIObjectParser(BaseOpenAPIObjectParser):
 
     def get_required(self, default: Any = None) -> List[str]:
         if default is not None:
@@ -21,10 +33,21 @@ class OpenAPIObjectParser:
             return self._data["properties"]
 
 
-class OpenAPIResponseParser:
+class BaseOpenAPIResponseParser(metaclass=ABCMeta):
 
     def __init__(self, data: dict):
         self._data = data
+
+    @abstractmethod
+    def get_content(self, value_format: str) -> Dict[str, dict]:
+        pass
+
+    @abstractmethod
+    def exist_in_content(self, value_format: str) -> bool:
+        pass
+
+
+class OpenAPIResponseParser(BaseOpenAPIResponseParser):
 
     def get_content(self, value_format: str) -> Dict[str, dict]:
         return self._data["content"][value_format]["schema"]
@@ -33,10 +56,33 @@ class OpenAPIResponseParser:
         return value_format in self._data["content"].keys()
 
 
-class OpenAPIRequestParametersParser:
+class BaseOpenAPIRequestParametersParser(metaclass=ABCMeta):
 
     def __init__(self, data: dict):
         self._data = data
+
+    @abstractmethod
+    def get_name(self) -> str:
+        pass
+
+    @abstractmethod
+    def get_required(self) -> str:
+        pass
+
+    @abstractmethod
+    def get_type(self) -> str:
+        pass
+
+    @abstractmethod
+    def get_default(self) -> Optional[str]:
+        pass
+
+    @abstractmethod
+    def get_items(self):
+        pass
+
+
+class OpenAPIRequestParametersParser(BaseOpenAPIRequestParametersParser):
 
     def get_name(self) -> str:
         return self._data["name"]
@@ -54,10 +100,29 @@ class OpenAPIRequestParametersParser:
         return self._data.get("items", None)
 
 
-class OpenAPIPathParser:
+class BaseOpenAPIPathParser(metaclass=ABCMeta):
 
     def __init__(self, data: dict):
         self._data = data
+
+    @abstractmethod
+    def get_request_parameters(self) -> List[dict]:
+        pass
+
+    @abstractmethod
+    def get_response(self, status_code: str) -> dict:
+        pass
+
+    @abstractmethod
+    def exist_in_response(self, status_code: str) -> bool:
+        pass
+
+    @abstractmethod
+    def get_all_tags(self) -> List[str]:
+        pass
+
+
+class OpenAPIPathParser(BaseOpenAPIPathParser):
 
     def get_request_parameters(self) -> List[dict]:
         return self._data["parameters"]
@@ -72,10 +137,21 @@ class OpenAPIPathParser:
         return self._data.get("tags", [])
 
 
-class OpenAPITagParser:
+class BaseOpenAPITagParser(metaclass=ABCMeta):
 
     def __init__(self, data: dict):
         self._data = data
+
+    @abstractmethod
+    def get_name(self):
+        pass
+
+    @abstractmethod
+    def get_description(self):
+        pass
+
+
+class OpenAPITagParser(BaseOpenAPITagParser):
 
     def get_name(self):
         return self._data["name"]
@@ -84,7 +160,7 @@ class OpenAPITagParser:
         return self._data["description"]
 
 
-class OpenAPIParser:
+class BaseOpenAPIParser(metaclass=ABCMeta):
 
     def __init__(self, file: str = "", data: Dict = {}):
         if file:
@@ -98,6 +174,21 @@ class OpenAPIParser:
             self._data = data
 
         assert self._data, "No any data. Parse OpenAPI config fail."
+
+    @abstractmethod
+    def get_paths(self) -> Dict[str, Dict]:
+        pass
+
+    @abstractmethod
+    def get_tags(self) -> List[dict]:
+        pass
+
+    @abstractmethod
+    def get_objects(self) -> Dict[str, dict]:
+        pass
+
+
+class OpenAPIParser(BaseOpenAPIParser):
 
     def get_paths(self) -> Dict[str, Dict]:
         return self._data["paths"]

--- a/pymock_api/model/openapi/_parse.py
+++ b/pymock_api/model/openapi/_parse.py
@@ -107,3 +107,24 @@ class OpenAPIParser:
 
     def get_objects(self) -> Dict[str, dict]:
         return self._data.get("definitions", {})
+
+
+class OpenAPIParserFactory:
+
+    def entire_api(self, file: str = "", data: Dict = {}) -> OpenAPIParser:
+        return OpenAPIParser(file=file, data=data)
+
+    def tag(self, data: Dict) -> OpenAPITagParser:
+        return OpenAPITagParser(data=data)
+
+    def path(self, data: Dict) -> OpenAPIPathParser:
+        return OpenAPIPathParser(data=data)
+
+    def request_parameters(self, data: Dict) -> OpenAPIRequestParametersParser:
+        return OpenAPIRequestParametersParser(data=data)
+
+    def response(self, data: Dict) -> OpenAPIResponseParser:
+        return OpenAPIResponseParser(data=data)
+
+    def object(self, data: Dict) -> OpenAPIObjectParser:
+        return OpenAPIObjectParser(data=data)

--- a/pymock_api/model/openapi/_parse.py
+++ b/pymock_api/model/openapi/_parse.py
@@ -107,24 +107,3 @@ class OpenAPIParser:
 
     def get_objects(self) -> Dict[str, dict]:
         return self._data.get("definitions", {})
-
-
-class OpenAPIParserFactory:
-
-    def entire_config(self, file: str = "", data: Dict = {}) -> OpenAPIParser:
-        return OpenAPIParser(file=file, data=data)
-
-    def tag(self, data: Dict) -> OpenAPITagParser:
-        return OpenAPITagParser(data=data)
-
-    def path(self, data: Dict) -> OpenAPIPathParser:
-        return OpenAPIPathParser(data=data)
-
-    def request_parameters(self, data: Dict) -> OpenAPIRequestParametersParser:
-        return OpenAPIRequestParametersParser(data=data)
-
-    def response(self, data: Dict) -> OpenAPIResponseParser:
-        return OpenAPIResponseParser(data=data)
-
-    def object(self, data: Dict) -> OpenAPIObjectParser:
-        return OpenAPIObjectParser(data=data)

--- a/pymock_api/model/openapi/_parse.py
+++ b/pymock_api/model/openapi/_parse.py
@@ -111,7 +111,7 @@ class OpenAPIParser:
 
 class OpenAPIParserFactory:
 
-    def entire_api(self, file: str = "", data: Dict = {}) -> OpenAPIParser:
+    def entire_config(self, file: str = "", data: Dict = {}) -> OpenAPIParser:
         return OpenAPIParser(file=file, data=data)
 
     def tag(self, data: Dict) -> OpenAPITagParser:

--- a/pymock_api/model/openapi/_parser_factory.py
+++ b/pymock_api/model/openapi/_parser_factory.py
@@ -1,6 +1,13 @@
+from abc import ABCMeta, abstractmethod
 from typing import Dict
 
 from ._parse import (
+    BaseOpenAPIObjectParser,
+    BaseOpenAPIParser,
+    BaseOpenAPIPathParser,
+    BaseOpenAPIRequestParametersParser,
+    BaseOpenAPIResponseParser,
+    BaseOpenAPITagParser,
     OpenAPIObjectParser,
     OpenAPIParser,
     OpenAPIPathParser,
@@ -10,7 +17,34 @@ from ._parse import (
 )
 
 
-class OpenAPIParserFactory:
+class BaseOpenAPIParserFactory(metaclass=ABCMeta):
+
+    @abstractmethod
+    def entire_config(self, file: str = "", data: Dict = {}) -> BaseOpenAPIParser:
+        pass
+
+    @abstractmethod
+    def tag(self, data: Dict) -> BaseOpenAPITagParser:
+        pass
+
+    @abstractmethod
+    def path(self, data: Dict) -> BaseOpenAPIPathParser:
+        pass
+
+    @abstractmethod
+    def request_parameters(self, data: Dict) -> BaseOpenAPIRequestParametersParser:
+        pass
+
+    @abstractmethod
+    def response(self, data: Dict) -> BaseOpenAPIResponseParser:
+        pass
+
+    @abstractmethod
+    def object(self, data: Dict) -> BaseOpenAPIObjectParser:
+        pass
+
+
+class OpenAPIParserFactory(BaseOpenAPIParserFactory):
 
     def entire_config(self, file: str = "", data: Dict = {}) -> OpenAPIParser:
         return OpenAPIParser(file=file, data=data)

--- a/pymock_api/model/openapi/_parser_factory.py
+++ b/pymock_api/model/openapi/_parser_factory.py
@@ -1,0 +1,31 @@
+from typing import Dict
+
+from ._parse import (
+    OpenAPIObjectParser,
+    OpenAPIParser,
+    OpenAPIPathParser,
+    OpenAPIRequestParametersParser,
+    OpenAPIResponseParser,
+    OpenAPITagParser,
+)
+
+
+class OpenAPIParserFactory:
+
+    def entire_config(self, file: str = "", data: Dict = {}) -> OpenAPIParser:
+        return OpenAPIParser(file=file, data=data)
+
+    def tag(self, data: Dict) -> OpenAPITagParser:
+        return OpenAPITagParser(data=data)
+
+    def path(self, data: Dict) -> OpenAPIPathParser:
+        return OpenAPIPathParser(data=data)
+
+    def request_parameters(self, data: Dict) -> OpenAPIRequestParametersParser:
+        return OpenAPIRequestParametersParser(data=data)
+
+    def response(self, data: Dict) -> OpenAPIResponseParser:
+        return OpenAPIResponseParser(data=data)
+
+    def object(self, data: Dict) -> OpenAPIObjectParser:
+        return OpenAPIObjectParser(data=data)

--- a/pymock_api/model/openapi/config.py
+++ b/pymock_api/model/openapi/config.py
@@ -79,7 +79,7 @@ class _YamlSchema:
         return _get_schema(get_component_definition(), schema_path, 0)
 
 
-class BaseSwaggerDataModel(metaclass=ABCMeta):
+class BaseOpenAPIDataModel(metaclass=ABCMeta):
 
     def __init__(self):
         self._config_parser_factory: BaseOpenAPIParserFactory = OpenAPIParserFactory()
@@ -89,13 +89,13 @@ class BaseSwaggerDataModel(metaclass=ABCMeta):
         pass
 
 
-class Transferable(BaseSwaggerDataModel):
+class Transferable(BaseOpenAPIDataModel):
     @abstractmethod
     def to_api_config(self, **kwargs) -> _Config:
         pass
 
 
-class Tag(BaseSwaggerDataModel):
+class Tag(BaseOpenAPIDataModel):
     def __init__(self):
         super().__init__()
         self.name: str = ""

--- a/pymock_api/model/openapi/config.py
+++ b/pymock_api/model/openapi/config.py
@@ -382,13 +382,13 @@ class API(Transferable):
         return mock_api
 
 
-class SwaggerConfig(Transferable):
+class OpenAPIDocumentConfig(Transferable):
     def __init__(self):
         super().__init__()
         self.paths: List[API] = []
         self.tags: List[Tag] = []
 
-    def deserialize(self, data: Dict) -> "SwaggerConfig":
+    def deserialize(self, data: Dict) -> "OpenAPIDocumentConfig":
         openapi_parser = self._config_parser_factory.entire_config(data=data)
         apis = openapi_parser.get_paths()
         for api_path, api_props in apis.items():
@@ -408,19 +408,19 @@ class SwaggerConfig(Transferable):
     def to_api_config(self, base_url: str = "") -> APIConfig:  # type: ignore[override]
         api_config = APIConfig(name="", description="", apis=MockAPIs(base=BaseConfig(url=base_url), apis={}))
         assert api_config.apis is not None and api_config.apis.apis == {}
-        for swagger_api in self.paths:
-            base_url = self._align_url_format(base_url, swagger_api)
-            api_config.apis.apis[self._generate_api_key(base_url, swagger_api)] = swagger_api.to_api_config(
+        for openapi_doc_api in self.paths:
+            base_url = self._align_url_format(base_url, openapi_doc_api)
+            api_config.apis.apis[self._generate_api_key(base_url, openapi_doc_api)] = openapi_doc_api.to_api_config(
                 base_url=base_url
             )
         return api_config
 
-    def _align_url_format(self, base_url: str, swagger_api: API) -> str:
-        if swagger_api.path[0] != "/":
-            swagger_api.path = f"/{swagger_api.path}"
+    def _align_url_format(self, base_url: str, openapi_doc_api: API) -> str:
+        if openapi_doc_api.path[0] != "/":
+            openapi_doc_api.path = f"/{openapi_doc_api.path}"
         if base_url and base_url[0] != "/":
             base_url = f"/{base_url}"
         return base_url
 
-    def _generate_api_key(self, base_url: str, swagger_api: API) -> str:
-        return "_".join([swagger_api.http_method, swagger_api.path.replace(base_url, "")[1:].replace("/", "_")])
+    def _generate_api_key(self, base_url: str, openapi_doc_api: API) -> str:
+        return "_".join([openapi_doc_api.http_method, openapi_doc_api.path.replace(base_url, "")[1:].replace("/", "_")])

--- a/pymock_api/model/openapi/config.py
+++ b/pymock_api/model/openapi/config.py
@@ -6,8 +6,8 @@ from .. import APIConfig, MockAPI, MockAPIs
 from ..api_config import BaseConfig, _Config
 from ..api_config.apis import APIParameter as PyMockAPIParameter
 from ..enums import ResponseStrategy
-from ._parse import OpenAPIParser, OpenAPIPathParser
-from ._parser_factory import OpenAPIParserFactory
+from ._parse import BaseOpenAPIParser, BaseOpenAPIPathParser
+from ._parser_factory import BaseOpenAPIParserFactory, OpenAPIParserFactory
 
 Self = Any
 
@@ -42,7 +42,7 @@ def get_component_definition() -> Dict:
     return ComponentDefinition
 
 
-def set_component_definition(openapi_parser: OpenAPIParser) -> None:
+def set_component_definition(openapi_parser: BaseOpenAPIParser) -> None:
     global ComponentDefinition
     ComponentDefinition = openapi_parser.get_objects()
 
@@ -82,7 +82,7 @@ class _YamlSchema:
 class BaseSwaggerDataModel(metaclass=ABCMeta):
 
     def __init__(self):
-        self._config_parser_factory: OpenAPIParserFactory = OpenAPIParserFactory()
+        self._config_parser_factory: BaseOpenAPIParserFactory = OpenAPIParserFactory()
 
     @abstractmethod
     def deserialize(self, data: Dict) -> Self:
@@ -235,7 +235,7 @@ class API(Transferable):
             )
         return parameters
 
-    def _process_response(self, openapi_path_parser: OpenAPIPathParser, strategy: ResponseStrategy) -> dict:
+    def _process_response(self, openapi_path_parser: BaseOpenAPIPathParser, strategy: ResponseStrategy) -> dict:
         assert openapi_path_parser.exist_in_response(status_code="200") is True
         status_200_response = openapi_path_parser.get_response(status_code="200")
         if strategy is ResponseStrategy.OBJECT:

--- a/pymock_api/model/openapi/config.py
+++ b/pymock_api/model/openapi/config.py
@@ -388,7 +388,7 @@ class SwaggerConfig(Transferable):
         self.tags: List[Tag] = []
 
     def deserialize(self, data: Dict) -> "SwaggerConfig":
-        openapi_parser = self._config_parser_factory.entire_api(data=data)
+        openapi_parser = self._config_parser_factory.entire_config(data=data)
         apis = openapi_parser.get_paths()
         for api_path, api_props in apis.items():
             for one_api_http_method, one_api_details in api_props.items():

--- a/pymock_api/model/openapi/config.py
+++ b/pymock_api/model/openapi/config.py
@@ -6,7 +6,8 @@ from .. import APIConfig, MockAPI, MockAPIs
 from ..api_config import BaseConfig, _Config
 from ..api_config.apis import APIParameter as PyMockAPIParameter
 from ..enums import ResponseStrategy
-from ._parse import OpenAPIParser, OpenAPIParserFactory, OpenAPIPathParser
+from ._parse import OpenAPIParser, OpenAPIPathParser
+from ._parser_factory import OpenAPIParserFactory
 
 Self = Any
 

--- a/test/unit_test/model/init.py
+++ b/test/unit_test/model/init.py
@@ -95,6 +95,6 @@ def test_deserialize_subcommand_get_args(mock_parser_arguments: Mock):
 
 
 def test_deserialize_swagger_api_config():
-    with patch("pymock_api.model.SwaggerConfig.deserialize") as mock_deserialize_swagger_config_function:
+    with patch("pymock_api.model.OpenAPIDocumentConfig.deserialize") as mock_deserialize_swagger_config_function:
         deserialize_swagger_api_config(data={"some key": "some value"})
         mock_deserialize_swagger_config_function.assert_called_once_with(data={"some key": "some value"})

--- a/test/unit_test/model/openapi/config.py
+++ b/test/unit_test/model/openapi/config.py
@@ -17,7 +17,7 @@ from pymock_api.model.openapi._parse import OpenAPIParser, OpenAPIPathParser
 from pymock_api.model.openapi.config import (
     API,
     APIParameter,
-    SwaggerConfig,
+    OpenAPIDocumentConfig,
     Transferable,
     _YamlSchema,
     convert_js_type,
@@ -377,18 +377,18 @@ class TestAPI(_SwaggerDataModelTestSuite):
 
 class TestSwaggerConfig(_SwaggerDataModelTestSuite):
     @pytest.fixture(scope="function")
-    def data_model(self) -> SwaggerConfig:
-        return SwaggerConfig()
+    def data_model(self) -> OpenAPIDocumentConfig:
+        return OpenAPIDocumentConfig()
 
     @pytest.mark.parametrize("swagger_api_doc_data", SWAGGER_API_DOC_JSON)
     def test_deserialize(self, swagger_api_doc_data: dict, data_model: Transferable):
         set_component_definition(OpenAPIParser(data=swagger_api_doc_data))
         super().test_deserialize(swagger_api_doc_data, data_model)
 
-    def _initial(self, data: SwaggerConfig) -> None:
+    def _initial(self, data: OpenAPIDocumentConfig) -> None:
         data.paths = []
 
-    def _verify_result(self, data: SwaggerConfig, og_data: dict) -> None:
+    def _verify_result(self, data: OpenAPIDocumentConfig, og_data: dict) -> None:
         # TODO: Remove this deprecated test criteria if it ensure
         # def _get_api_param(name: str) -> Optional[dict]:
         #     swagger_api_params = og_data["paths"][api.path][api.http_method]["parameters"]
@@ -412,7 +412,7 @@ class TestSwaggerConfig(_SwaggerDataModelTestSuite):
             #     assert api_param.value_type == convert_js_type(one_swagger_api_param["schema"]["type"])
             #     assert api_param.default == one_swagger_api_param["schema"]["default"]
 
-    def _given_props(self, data_model: SwaggerConfig) -> None:
+    def _given_props(self, data_model: OpenAPIDocumentConfig) -> None:
         params = APIParameter()
         params.name = "arg1"
         params.required = False
@@ -427,7 +427,7 @@ class TestSwaggerConfig(_SwaggerDataModelTestSuite):
 
         data_model.paths = [api]
 
-    def _verify_api_config_model(self, under_test: APIConfig, data_from: SwaggerConfig) -> None:
+    def _verify_api_config_model(self, under_test: APIConfig, data_from: OpenAPIDocumentConfig) -> None:
         assert len(under_test.apis.apis.keys()) == len(data_from.paths)
         for api_path, api_details in under_test.apis.apis.items():
             expect_apis = list(
@@ -461,7 +461,7 @@ class TestSwaggerConfig(_SwaggerDataModelTestSuite):
             ("api/v1/test", "api/v1/test/foo-home"),
         ],
     )
-    def test__align_url_format(self, base_url: str, api_path: str, data_model: SwaggerConfig):
+    def test__align_url_format(self, base_url: str, api_path: str, data_model: OpenAPIDocumentConfig):
         api = API()
         api.path = api_path
         base_url = data_model._align_url_format(base_url, api)


### PR DESCRIPTION
### _Target_

* Extract all logic about OpenAPI documentation parsing as abstractions.


### _Effecting Scope_

* Nothing, just refactoring.


### _Description_

* Add new sub-package **_openapi_**.
* Extract the logic about instantiating parser objects into another object as factory role.
* Extract an abstractions:
    * Each parser objects
    * Factory object
* Rename the data modals to be more clearing its meaning.
