### PR TITLE
🎉🎊🍾 [New Feature] Support parsing JavaScript data type *object* in response part configuration and fix some major issues.

### DIFF
--- a/pymock_api/model/enums.py
+++ b/pymock_api/model/enums.py
@@ -220,16 +220,17 @@ class ResponseStrategy(Enum):
             #             item[item_k] = random_value
             return [item_info]
 
-        print(f"[DEBUG in _handle_not_ref_data] resp_prop_data: {resp_prop_data}")
-        v_type = convert_js_type(resp_prop_data["type"])
-        if self is ResponseStrategy.OBJECT:
+        def _handle_each_data_types_response_with_object_strategy(data: dict, v_type: str) -> dict:
             if locate(v_type) == list:
-                return _handle_list_type_value_with_object_strategy(resp_prop_data)
+                return _handle_list_type_value_with_object_strategy(data)
             elif locate(v_type) == dict:
                 return _handle_object_type_value_with_object_strategy(v_type)
             else:
                 return _handle_other_types_value_with_object_strategy(v_type)
-        else:
+
+        def _handle_each_data_types_response_with_non_object_strategy(
+            resp_prop_data: dict, v_type: str
+        ) -> Union[str, list]:
             if locate(v_type) == list:
                 return _handle_list_type_value_with_non_object_strategy(resp_prop_data)
             elif locate(v_type) == dict:
@@ -249,6 +250,38 @@ class ResponseStrategy(Enum):
                 return "random file output stream"
             else:
                 raise NotImplementedError
+
+        print(f"[DEBUG in _handle_not_ref_data] resp_prop_data: {resp_prop_data}")
+        v_type = convert_js_type(resp_prop_data["type"])
+        if self is ResponseStrategy.OBJECT:
+            return _handle_each_data_types_response_with_object_strategy(resp_prop_data, v_type)
+            # if locate(v_type) == list:
+            #     return _handle_list_type_value_with_object_strategy(resp_prop_data)
+            # elif locate(v_type) == dict:
+            #     return _handle_object_type_value_with_object_strategy(v_type)
+            # else:
+            #     return _handle_other_types_value_with_object_strategy(v_type)
+        else:
+            return _handle_each_data_types_response_with_non_object_strategy(resp_prop_data, v_type)
+            # if locate(v_type) == list:
+            #     return _handle_list_type_value_with_non_object_strategy(resp_prop_data)
+            # elif locate(v_type) == dict:
+            #     # FIXME: handle the reference like object type
+            #     return "random object value"
+            # elif locate(v_type) == str:
+            #     # lowercase_letters = string.ascii_lowercase
+            #     # k_value = "".join([random.choice(lowercase_letters) for _ in range(5)])
+            #     return "random string value"
+            # elif locate(v_type) == int:
+            #     # k_value = int("".join([random.choice([f"{i}" for i in range(10)]) for _ in range(5)]))
+            #     return "random integer value"
+            # elif locate(v_type) == bool:
+            #     return "random boolean value"
+            # elif v_type == "file":
+            #     # TODO: Handle the file download feature
+            #     return "random file output stream"
+            # else:
+            #     raise NotImplementedError
 
 
 class ConfigLoadingOrderKey(Enum):

--- a/pymock_api/model/enums.py
+++ b/pymock_api/model/enums.py
@@ -66,39 +66,37 @@ class ResponseStrategy(Enum):
         self,
         resp_prop_data: dict,
         get_schema_parser_factory: Callable,
-        has_ref_callback: Callable,
+        # has_ref_callback: Callable,
         get_ref_callback: Callable,
     ) -> Union[str, list, dict]:
 
-        def _handle_list_type_data(
-            data: dict, ref_val_process_callback: Callable, noref_val_process_callback: Callable, response: dict = {}
-        ) -> dict:
+        def _handle_list_type_data(data: dict, noref_val_process_callback: Callable, response: dict = {}) -> dict:
             single_response = get_ref_callback(data["items"])
             parser = get_schema_parser_factory().object(single_response)
             single_response_properties = parser.get_properties(default={})
             if single_response_properties:
                 for item_k, item_v in parser.get_properties().items():
-                    if has_ref_callback(item_v):
-                        # TODO: Should consider the algorithm to handle nested reference case
-                        print("[WARNING] Not implement yet ...")
-                        response = ref_val_process_callback(item_k, item_v, response)
-                    else:
-                        response = noref_val_process_callback(item_k, item_v, response)
-                        # item_type = convert_js_type(item_v["type"])
-                        # # TODO: Set the *required* property correctly
-                        # item = {"name": item_k, "required": True, "type": item_type}
-                        # assert isinstance(
-                        #     response_data_prop["items"], list
-                        # ), "The data type of property *items* must be *list*."
-                        # response_data_prop["items"].append(item)
+                    # if has_ref_callback(item_v):
+                    #     # TODO: Should consider the algorithm to handle nested reference case
+                    #     print("[WARNING] Not implement yet ...")
+                    #     response = ref_val_process_callback(item_k, item_v, response)
+                    # else:
+                    response = noref_val_process_callback(item_k, item_v, response)
+                    # item_type = convert_js_type(item_v["type"])
+                    # # TODO: Set the *required* property correctly
+                    # item = {"name": item_k, "required": True, "type": item_type}
+                    # assert isinstance(
+                    #     response_data_prop["items"], list
+                    # ), "The data type of property *items* must be *list*."
+                    # response_data_prop["items"].append(item)
             return response
 
         def _handle_list_type_value_with_object_strategy(data: dict) -> dict:
 
-            def _ref_process_callback(item_k: str, item_v: dict, response_data_prop: dict) -> dict:
-                # TODO: Should consider the algorithm to handle nested reference case
-                print("[WARNING] Not implement yet ...")
-                return response_data_prop
+            # def _ref_process_callback(item_k: str, item_v: dict, response_data_prop: dict) -> dict:
+            #     # TODO: Should consider the algorithm to handle nested reference case
+            #     print("[WARNING] Not implement yet ...")
+            #     return response_data_prop
 
             def _noref_process_callback(item_k: str, item_v: dict, response_data_prop: dict) -> dict:
                 item_type = convert_js_type(item_v["type"])
@@ -121,7 +119,7 @@ class ResponseStrategy(Enum):
             }
             response_data_prop = _handle_list_type_data(
                 data=data,
-                ref_val_process_callback=_ref_process_callback,
+                # ref_val_process_callback=_ref_process_callback,
                 noref_val_process_callback=_noref_process_callback,
                 response=response_data_prop,
             )
@@ -169,10 +167,10 @@ class ResponseStrategy(Enum):
 
         def _handle_list_type_value_with_non_object_strategy(data: dict) -> list:
 
-            def _ref_process_callback(item_k: str, item_v: dict, response_data_prop: dict) -> dict:
-                # TODO: Should consider the algorithm to handle nested reference case
-                print("[WARNING] Not implement yet ...")
-                return response_data_prop
+            # def _ref_process_callback(item_k: str, item_v: dict, response_data_prop: dict) -> dict:
+            #     # TODO: Should consider the algorithm to handle nested reference case
+            #     print("[WARNING] Not implement yet ...")
+            #     return response_data_prop
 
             def _noref_process_callback(item_k: str, item_v: dict, item: dict) -> dict:
                 item_type = convert_js_type(item_v["type"])
@@ -192,7 +190,7 @@ class ResponseStrategy(Enum):
             item_info: dict = {}
             item_info = _handle_list_type_data(
                 data=data,
-                ref_val_process_callback=_ref_process_callback,
+                # ref_val_process_callback=_ref_process_callback,
                 noref_val_process_callback=_noref_process_callback,
                 response=item_info,
             )

--- a/pymock_api/model/enums.py
+++ b/pymock_api/model/enums.py
@@ -31,6 +31,35 @@ class ResponseStrategy(Enum):
         else:
             return v
 
+    def initial_response_data(self) -> Dict[str, Union["ResponseStrategy", list, dict]]:
+        response_data: Dict[str, Union["ResponseStrategy", list, dict]] = {
+            "strategy": self,
+            # "data": None,
+        }
+        if self is ResponseStrategy.OBJECT:
+            response_data["data"] = []
+        else:
+            response_data["data"] = {}
+        return response_data
+
+    def generate_response(
+        self,
+        property_value: dict,
+        get_schema_parser_factory: Callable,
+        has_ref_callback: Callable,
+        get_ref_callback: Callable,
+    ) -> Union[str, list, dict]:
+        if not property_value:
+            return self.generate_empty_response()
+        if has_ref_callback(property_value):
+            return self.generate_response_from_reference(get_ref_callback(property_value))
+        else:
+            return self.generate_response_from_data(
+                resp_prop_data=property_value,
+                get_schema_parser_factory=get_schema_parser_factory,
+                get_ref_callback=get_ref_callback,
+            )
+
     def generate_empty_response(self) -> Union[str, Dict[str, Any]]:
         if self is ResponseStrategy.OBJECT:
             return {

--- a/pymock_api/model/enums.py
+++ b/pymock_api/model/enums.py
@@ -1,6 +1,9 @@
 import re
 from enum import Enum
-from typing import Callable, Dict, Optional, Union
+from pydoc import locate
+from typing import Any, Callable, Dict, Optional, Union
+
+from pymock_api.model.openapi._js_handlers import convert_js_type
 
 
 class Format(Enum):
@@ -27,6 +30,153 @@ class ResponseStrategy(Enum):
             return ResponseStrategy(v.lower())
         else:
             return v
+
+    def generate_empty_response(self) -> Union[str, Dict[str, Any]]:
+        if self is ResponseStrategy.OBJECT:
+            return {
+                "name": "",
+                # TODO: Set the *required* property correctly
+                "required": False,
+                # TODO: Set the *type* property correctly
+                "type": None,
+                # TODO: Set the *format* property correctly
+                "format": None,
+                "items": [],
+            }
+        else:
+            return "empty value"
+
+    def generate_response_from_reference(self, ref_data: dict) -> Union[str, Dict[str, Any]]:
+        if self is ResponseStrategy.OBJECT:
+            return {
+                "name": "",
+                # TODO: Set the *required* property correctly
+                "required": True,
+                # TODO: Set the *type* property correctly
+                "type": "file",
+                # TODO: Set the *format* property correctly
+                "format": None,
+                "items": [],
+                "FIXME": "Handle the reference",
+            }
+        else:
+            return "FIXME: Handle the reference"
+
+    def generate_response_from_data(
+        self,
+        resp_prop_data: dict,
+        get_schema_parser_factory: Callable,
+        has_ref_callback: Callable,
+        get_ref_callback: Callable,
+    ) -> Union[str, list, dict]:
+
+        def _handle_list_type_value_with_object_strategy(data: dict) -> dict:
+            response_data_prop = {
+                "name": "",
+                # TODO: Set the *required* property correctly
+                "required": True,
+                "type": v_type,
+                # TODO: Set the *format* property correctly
+                "format": None,
+                "items": [],
+            }
+
+            single_response = get_ref_callback(data["items"])
+            parser = get_schema_parser_factory().object(single_response)
+            single_response_properties = parser.get_properties(default={})
+            if single_response_properties:
+                for item_k, item_v in parser.get_properties().items():
+                    if has_ref_callback(item_v):
+                        # TODO: Should consider the algorithm to handle nested reference case
+                        print("[WARNING] Not implement yet ...")
+                    else:
+                        item_type = convert_js_type(item_v["type"])
+                        # TODO: Set the *required* property correctly
+                        item = {"name": item_k, "required": True, "type": item_type}
+                        assert isinstance(
+                            response_data_prop["items"], list
+                        ), "The data type of property *items* must be *list*."
+                        response_data_prop["items"].append(item)
+            return response_data_prop
+
+        def _handle_object_type_value_with_object_strategy(v_type: str) -> dict:
+            # FIXME: handle the reference like object type
+            return {
+                "name": "",
+                # TODO: Set the *required* property correctly
+                "required": True,
+                "type": v_type,
+                # TODO: Set the *format* property correctly
+                "format": None,
+                "items": None,
+            }
+
+        def _handle_other_types_value_with_object_strategy(v_type: str) -> dict:
+            return {
+                "name": "",
+                # TODO: Set the *required* property correctly
+                "required": True,
+                "type": v_type,
+                # TODO: Set the *format* property correctly
+                "format": None,
+                "items": None,
+            }
+
+        def _handle_list_type_value_with_non_object_strategy(data: dict) -> list:
+            single_response = get_ref_callback(data["items"])
+            parser = get_schema_parser_factory().object(single_response)
+            item = {}
+            single_response_properties = parser.get_properties(default={})
+            if single_response_properties:
+                for item_k, item_v in parser.get_properties().items():
+                    if has_ref_callback(item_v):
+                        # TODO: Should consider the algorithm to handle nested reference case
+                        obj_item_type = convert_js_type(item_v["additionalProperties"]["type"])
+                        print("[WARNING] Not implement yet ...")
+                    else:
+                        item_type = convert_js_type(item_v["type"])
+                        if locate(item_type) is str:
+                            # lowercase_letters = string.ascii_lowercase
+                            # random_value = "".join([random.choice(lowercase_letters) for _ in range(5)])
+                            random_value = "random string value"
+                        elif locate(item_type) is int:
+                            # random_value = int(
+                            #     "".join([random.choice([f"{i}" for i in range(10)]) for _ in range(5)]))
+                            random_value = "random integer value"
+                        else:
+                            raise NotImplementedError
+                        item[item_k] = random_value
+            return [item]
+
+        print(f"[DEBUG in _handle_not_ref_data] resp_prop_data: {resp_prop_data}")
+        v_type = convert_js_type(resp_prop_data["type"])
+        if self is ResponseStrategy.OBJECT:
+            if locate(v_type) == list:
+                return _handle_list_type_value_with_object_strategy(resp_prop_data)
+            elif locate(v_type) == dict:
+                return _handle_object_type_value_with_object_strategy(v_type)
+            else:
+                return _handle_other_types_value_with_object_strategy(v_type)
+        else:
+            if locate(v_type) == list:
+                return _handle_list_type_value_with_non_object_strategy(resp_prop_data)
+            elif locate(v_type) == dict:
+                # FIXME: handle the reference like object type
+                return "random object value"
+            elif locate(v_type) == str:
+                # lowercase_letters = string.ascii_lowercase
+                # k_value = "".join([random.choice(lowercase_letters) for _ in range(5)])
+                return "random string value"
+            elif locate(v_type) == int:
+                # k_value = int("".join([random.choice([f"{i}" for i in range(10)]) for _ in range(5)]))
+                return "random integer value"
+            elif locate(v_type) == bool:
+                return "random boolean value"
+            elif v_type == "file":
+                # TODO: Handle the file download feature
+                return "random file output stream"
+            else:
+                raise NotImplementedError
 
 
 class ConfigLoadingOrderKey(Enum):

--- a/pymock_api/model/enums.py
+++ b/pymock_api/model/enums.py
@@ -58,6 +58,7 @@ class ResponseStrategy(Enum):
                 if self is ResponseStrategy.OBJECT:
                     # response_data_prop = self._process_response_value(property_value=v, strategy=strategy)
                     response_data_prop = self.generate_response(
+                        init_response=init_response,
                         property_value=v,
                         get_schema_parser_factory=get_schema_parser_factory,
                         has_ref_callback=has_ref_callback,
@@ -76,6 +77,7 @@ class ResponseStrategy(Enum):
                     ), "The response data type must be *dict* if its HTTP response strategy is not object."
                     # resp_data["data"][k] = self._process_response_value(property_value=v, strategy=strategy)
                     init_response["data"][k] = self.generate_response(
+                        init_response=init_response,
                         property_value=v,
                         get_schema_parser_factory=get_schema_parser_factory,
                         has_ref_callback=has_ref_callback,
@@ -94,6 +96,7 @@ class ResponseStrategy(Enum):
         if self is ResponseStrategy.OBJECT:
             # response_data_prop = self._process_response_value(property_value=_data, strategy=strategy)
             response_data_prop = self.generate_response(
+                init_response=init_response,
                 property_value=data,
                 get_schema_parser_factory=get_schema_parser_factory,
                 has_ref_callback=has_ref_callback,
@@ -110,6 +113,7 @@ class ResponseStrategy(Enum):
             ), "The response data type must be *dict* if its HTTP response strategy is not object."
             # resp_data["data"][0] = self._process_response_value(property_value=_data, strategy=strategy)
             init_response["data"][0] = self.generate_response(
+                init_response=init_response,
                 property_value=data,
                 get_schema_parser_factory=get_schema_parser_factory,
                 has_ref_callback=has_ref_callback,
@@ -119,6 +123,7 @@ class ResponseStrategy(Enum):
 
     def generate_response(
         self,
+        init_response: dict,
         property_value: dict,
         get_schema_parser_factory: Callable,
         has_ref_callback: Callable,
@@ -130,8 +135,10 @@ class ResponseStrategy(Enum):
             return self.generate_response_from_reference(get_ref_callback(property_value))
         else:
             return self.generate_response_from_data(
+                init_response=init_response,
                 resp_prop_data=property_value,
                 get_schema_parser_factory=get_schema_parser_factory,
+                has_ref_callback=has_ref_callback,
                 get_ref_callback=get_ref_callback,
             )
 
@@ -168,31 +175,56 @@ class ResponseStrategy(Enum):
 
     def generate_response_from_data(
         self,
+        init_response: dict,
         resp_prop_data: dict,
         get_schema_parser_factory: Callable,
-        # has_ref_callback: Callable,
+        has_ref_callback: Callable,
         get_ref_callback: Callable,
     ) -> Union[str, list, dict]:
 
         def _handle_list_type_data(data: dict, noref_val_process_callback: Callable, response: dict = {}) -> dict:
-            single_response = get_ref_callback(data["items"])
-            parser = get_schema_parser_factory().object(single_response)
-            single_response_properties = parser.get_properties(default={})
-            if single_response_properties:
-                for item_k, item_v in parser.get_properties().items():
-                    # if has_ref_callback(item_v):
-                    #     # TODO: Should consider the algorithm to handle nested reference case
-                    #     print("[WARNING] Not implement yet ...")
-                    #     response = ref_val_process_callback(item_k, item_v, response)
-                    # else:
-                    response = noref_val_process_callback(item_k, item_v, response)
-                    # item_type = convert_js_type(item_v["type"])
-                    # # TODO: Set the *required* property correctly
-                    # item = {"name": item_k, "required": True, "type": item_type}
-                    # assert isinstance(
-                    #     response_data_prop["items"], list
-                    # ), "The data type of property *items* must be *list*."
-                    # response_data_prop["items"].append(item)
+            items_data = data["items"]
+            if has_ref_callback(items_data):
+                single_response = get_ref_callback(items_data)
+                parser = get_schema_parser_factory().object(single_response)
+                single_response_properties = parser.get_properties(default={})
+                if single_response_properties:
+                    for item_k, item_v in parser.get_properties().items():
+                        # if has_ref_callback(item_v):
+                        #     # TODO: Should consider the algorithm to handle nested reference case
+                        #     print("[WARNING] Not implement yet ...")
+                        #     response = ref_val_process_callback(item_k, item_v, response)
+                        # else:
+                        response = noref_val_process_callback(item_k, item_v, response)
+                        # item_type = convert_js_type(item_v["type"])
+                        # # TODO: Set the *required* property correctly
+                        # item = {"name": item_k, "required": True, "type": item_type}
+                        # assert isinstance(
+                        #     response_data_prop["items"], list
+                        # ), "The data type of property *items* must be *list*."
+                        # response_data_prop["items"].append(item)
+            else:
+                print(f"[DEBUG in _handle_list_type_data] init_response: {init_response}")
+                print(f"[DEBUG in _handle_list_type_data] items_data: {items_data}")
+                response_value = self.generate_response_from_data(  # type: ignore[assignment]
+                    init_response=init_response,
+                    resp_prop_data=items_data,
+                    get_schema_parser_factory=get_schema_parser_factory,
+                    get_ref_callback=get_ref_callback,
+                    has_ref_callback=has_ref_callback,
+                )
+                print(f"[DEBUG in _handle_list_type_data] response_value: {response_value}")
+                if isinstance(response_value, list):
+                    # TODO: Need to check whether here logic is valid or not
+                    response = response_value
+                elif isinstance(response_value, dict):
+                    # TODO: Need to check whether here logic is valid or not
+                    response = response_value
+                elif isinstance(response_value, str):
+                    response = response_value
+                else:
+                    raise TypeError(f"Not implement the process to handle the data type '{type(response_value)}' response.")
+                print(f"[DEBUG in _handle_list_type_data] response: {response}")
             return response
 
         def _handle_list_type_value_with_object_strategy(data: dict) -> dict:
@@ -334,12 +366,29 @@ class ResponseStrategy(Enum):
 
         def _handle_each_data_types_response_with_non_object_strategy(
             resp_prop_data: dict, v_type: str
-        ) -> Union[str, list]:
+        ) -> Union[str, list, dict]:
             if locate(v_type) == list:
                 return _handle_list_type_value_with_non_object_strategy(resp_prop_data)
             elif locate(v_type) == dict:
                 # FIXME: handle the reference like object type
-                return "random object value"
+                additional_properties = resp_prop_data["additionalProperties"]
+                if has_ref_callback(additional_properties):
+                    return self.process_response_from_reference(
+                        init_response=init_response,
+                        data=additional_properties,
+                        get_schema_parser_factory=get_schema_parser_factory,
+                        has_ref_callback=has_ref_callback,
+                        get_ref_callback=get_ref_callback,
+                    )["data"]
+                else:
+                    return self.process_response_from_data(
+                        init_response=init_response,
+                        data=additional_properties,
+                        get_schema_parser_factory=get_schema_parser_factory,
+                        has_ref_callback=has_ref_callback,
+                        get_ref_callback=get_ref_callback,
+                    )["data"][0]
+                # return "random object value"
             elif locate(v_type) == str:
                 # lowercase_letters = string.ascii_lowercase
                 # k_value = "".join([random.choice(lowercase_letters) for _ in range(5)])

--- a/pymock_api/model/openapi/_js_handlers.py
+++ b/pymock_api/model/openapi/_js_handlers.py
@@ -9,6 +9,8 @@ def convert_js_type(t: str) -> str:
         return "list"
     elif t == "file":
         return "file"
+    elif t == "object":
+        return "dict"
     else:
         raise TypeError(f"Currently, it cannot parse JS type '{t}'.")
 

--- a/pymock_api/model/openapi/_parser.py
+++ b/pymock_api/model/openapi/_parser.py
@@ -401,7 +401,7 @@ class APIParser(BaseParser):
             return strategy.generate_response_from_data(
                 resp_prop_data=property_value,
                 get_schema_parser_factory=ensure_get_schema_parser_factory,
-                has_ref_callback=_YamlSchema.has_ref,
+                # has_ref_callback=_YamlSchema.has_ref,
                 get_ref_callback=_YamlSchema.get_schema_ref,
             )
             # return _handle_not_ref_data(property_value)

--- a/pymock_api/model/openapi/_parser.py
+++ b/pymock_api/model/openapi/_parser.py
@@ -281,6 +281,7 @@ class APIParser(BaseParser):
                 return "FIXME: Handle the reference"
 
         def _handle_not_ref_data(resp_prop_data: dict) -> Union[str, list, dict]:
+            print(f"[DEBUG in _handle_not_ref_data] resp_prop_data: {resp_prop_data}")
             v_type = convert_js_type(resp_prop_data["type"])
             if strategy is ResponseStrategy.OBJECT:
                 if locate(v_type) == list:
@@ -299,14 +300,29 @@ class APIParser(BaseParser):
                     single_response_properties = parser.get_properties(default={})
                     if single_response_properties:
                         for item_k, item_v in parser.get_properties().items():
-                            item_type = convert_js_type(item_v["type"])
-                            # TODO: Set the *required* property correctly
-                            item = {"name": item_k, "required": True, "type": item_type}
-                            assert isinstance(
-                                response_data_prop["items"], list
-                            ), "The data type of property *items* must be *list*."
-                            response_data_prop["items"].append(item)
+                            if _YamlSchema.has_ref(item_v):
+                                # TODO: Should consider the algorithm to handle nested reference case
+                                print("[WARNING] Not implement yet ...")
+                            else:
+                                item_type = convert_js_type(item_v["type"])
+                                # TODO: Set the *required* property correctly
+                                item = {"name": item_k, "required": True, "type": item_type}
+                                assert isinstance(
+                                    response_data_prop["items"], list
+                                ), "The data type of property *items* must be *list*."
+                                response_data_prop["items"].append(item)
                     return response_data_prop
+                if locate(v_type) == dict:
+                    # FIXME: handle the reference like object type
+                    return {
+                        "name": "",
+                        # TODO: Set the *required* property correctly
+                        "required": True,
+                        "type": v_type,
+                        # TODO: Set the *format* property correctly
+                        "format": None,
+                        "items": None,
+                    }
                 else:
                     return {
                         "name": "",
@@ -325,19 +341,27 @@ class APIParser(BaseParser):
                     single_response_properties = parser.get_properties(default={})
                     if single_response_properties:
                         for item_k, item_v in parser.get_properties().items():
-                            item_type = convert_js_type(item_v["type"])
-                            if locate(item_type) is str:
-                                # lowercase_letters = string.ascii_lowercase
-                                # random_value = "".join([random.choice(lowercase_letters) for _ in range(5)])
-                                random_value = "random string value"
-                            elif locate(item_type) is int:
-                                # random_value = int(
-                                #     "".join([random.choice([f"{i}" for i in range(10)]) for _ in range(5)]))
-                                random_value = "random integer value"
+                            if _YamlSchema.has_ref(item_v):
+                                # TODO: Should consider the algorithm to handle nested reference case
+                                obj_item_type = convert_js_type(item_v["additionalProperties"]["type"])
+                                print("[WARNING] Not implement yet ...")
                             else:
-                                raise NotImplementedError
-                            item[item_k] = random_value
+                                item_type = convert_js_type(item_v["type"])
+                                if locate(item_type) is str:
+                                    # lowercase_letters = string.ascii_lowercase
+                                    # random_value = "".join([random.choice(lowercase_letters) for _ in range(5)])
+                                    random_value = "random string value"
+                                elif locate(item_type) is int:
+                                    # random_value = int(
+                                    #     "".join([random.choice([f"{i}" for i in range(10)]) for _ in range(5)]))
+                                    random_value = "random integer value"
+                                else:
+                                    raise NotImplementedError
+                                item[item_k] = random_value
                     return [item]
+                elif locate(v_type) == dict:
+                    # FIXME: handle the reference like object type
+                    return "random object value"
                 elif locate(v_type) == str:
                     # lowercase_letters = string.ascii_lowercase
                     # k_value = "".join([random.choice(lowercase_letters) for _ in range(5)])

--- a/pymock_api/model/openapi/_parser.py
+++ b/pymock_api/model/openapi/_parser.py
@@ -262,9 +262,9 @@ class APIParser(BaseParser):
             else:
                 return "empty value"
 
-        def _handle_ref_data() -> Union[str, dict]:
+        def _handle_ref_data(resp_prop_data: dict) -> Union[str, dict]:
             # FIXME: Handle the reference
-            v_ref = _YamlSchema.get_schema_ref(property_value)
+            v_ref = _YamlSchema.get_schema_ref(resp_prop_data)
             if strategy is ResponseStrategy.OBJECT:
                 return {
                     "name": "",
@@ -280,8 +280,8 @@ class APIParser(BaseParser):
             else:
                 return "FIXME: Handle the reference"
 
-        def _handle_not_ref_data() -> Union[str, list, dict]:
-            v_type = convert_js_type(property_value["type"])
+        def _handle_not_ref_data(resp_prop_data: dict) -> Union[str, list, dict]:
+            v_type = convert_js_type(resp_prop_data["type"])
             if strategy is ResponseStrategy.OBJECT:
                 if locate(v_type) == list:
                     response_data_prop = {
@@ -294,7 +294,7 @@ class APIParser(BaseParser):
                         "items": [],
                     }
 
-                    single_response = _YamlSchema.get_schema_ref(property_value["items"])
+                    single_response = _YamlSchema.get_schema_ref(resp_prop_data["items"])
                     parser = self.schema_parser_factory.object(single_response)
                     single_response_properties = parser.get_properties(default={})
                     if single_response_properties:
@@ -319,7 +319,7 @@ class APIParser(BaseParser):
                     }
             else:
                 if locate(v_type) == list:
-                    single_response = _YamlSchema.get_schema_ref(property_value["items"])
+                    single_response = _YamlSchema.get_schema_ref(resp_prop_data["items"])
                     parser = self.schema_parser_factory.object(single_response)
                     item = {}
                     single_response_properties = parser.get_properties(default={})
@@ -356,9 +356,9 @@ class APIParser(BaseParser):
         if not property_value:
             return _handle_empty_data()
         if _YamlSchema.has_ref(property_value):
-            return _handle_ref_data()
+            return _handle_ref_data(property_value)
         else:
-            return _handle_not_ref_data()
+            return _handle_not_ref_data(property_value)
 
     def process_tags(self) -> List[str]:
         return self.parser.get_all_tags()

--- a/pymock_api/model/openapi/_parser.py
+++ b/pymock_api/model/openapi/_parser.py
@@ -76,6 +76,9 @@ class APIParameterParser(BaseParser):
 
 
 class APIParser(BaseParser):
+
+    Response_Content_Type: List[str] = ["application/json", "application/octet-stream", "*/*"]
+
     @property
     def parser(self) -> BaseOpenAPIPathSchemaParser:
         return cast(BaseOpenAPIPathSchemaParser, super().parser)
@@ -230,7 +233,7 @@ class APIParser(BaseParser):
         else:
             resp_parser = self.schema_parser_factory.response(status_200_response)
             resp_value_format = list(
-                filter(lambda vf: resp_parser.exist_in_content(value_format=vf), ["application/json", "*/*"])
+                filter(lambda vf: resp_parser.exist_in_content(value_format=vf), self.Response_Content_Type)
             )
             response_schema = resp_parser.get_content(value_format=resp_value_format[0])
             if _YamlSchema.has_ref(response_schema):

--- a/pymock_api/model/openapi/_parser.py
+++ b/pymock_api/model/openapi/_parser.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from collections import namedtuple
-from typing import Any, Dict, List, Optional, Type, cast
+from typing import Dict, List, Optional, Type, cast
 
 from ..enums import OpenAPIVersion, ResponseStrategy
 from ._base import (
@@ -177,66 +177,66 @@ class APIParser(BaseParser):
 
     def process_responses(self, strategy: ResponseStrategy) -> dict:
 
-        def _initial_response_model_with_ref_value(resp_data: Dict[str, Any], _data: dict) -> Dict[str, Any]:
-            response_schema_ref = _YamlSchema.get_schema_ref(_data)
-            parser = self.schema_parser_factory.object(response_schema_ref)
-            response_schema_properties: Optional[dict] = parser.get_properties(default=None)
-            if response_schema_properties:
-                for k, v in response_schema_properties.items():
-                    if strategy is ResponseStrategy.OBJECT:
-                        # response_data_prop = self._process_response_value(property_value=v, strategy=strategy)
-                        response_data_prop = strategy.generate_response(
-                            property_value=v,
-                            get_schema_parser_factory=ensure_get_schema_parser_factory,
-                            has_ref_callback=_YamlSchema.has_ref,
-                            get_ref_callback=_YamlSchema.get_schema_ref,
-                        )
-                        assert isinstance(response_data_prop, dict)
-                        response_data_prop["name"] = k
-                        response_data_prop["required"] = k in parser.get_required(default=[k])
-                        assert isinstance(
-                            resp_data["data"], list
-                        ), "The response data type must be *list* if its HTTP response strategy is object."
-                        resp_data["data"].append(response_data_prop)
-                    else:
-                        assert isinstance(
-                            resp_data["data"], dict
-                        ), "The response data type must be *dict* if its HTTP response strategy is not object."
-                        # resp_data["data"][k] = self._process_response_value(property_value=v, strategy=strategy)
-                        resp_data["data"][k] = strategy.generate_response(
-                            property_value=v,
-                            get_schema_parser_factory=ensure_get_schema_parser_factory,
-                            has_ref_callback=_YamlSchema.has_ref,
-                            get_ref_callback=_YamlSchema.get_schema_ref,
-                        )
-            return resp_data
+        # def _initial_response_model_with_ref_value(resp_data: Dict[str, Any], _data: dict) -> Dict[str, Any]:
+        #     response_schema_ref = _YamlSchema.get_schema_ref(_data)
+        #     parser = self.schema_parser_factory.object(response_schema_ref)
+        #     response_schema_properties: Optional[dict] = parser.get_properties(default=None)
+        #     if response_schema_properties:
+        #         for k, v in response_schema_properties.items():
+        #             if strategy is ResponseStrategy.OBJECT:
+        #                 # response_data_prop = self._process_response_value(property_value=v, strategy=strategy)
+        #                 response_data_prop = strategy.generate_response(
+        #                     property_value=v,
+        #                     get_schema_parser_factory=ensure_get_schema_parser_factory,
+        #                     has_ref_callback=_YamlSchema.has_ref,
+        #                     get_ref_callback=_YamlSchema.get_schema_ref,
+        #                 )
+        #                 assert isinstance(response_data_prop, dict)
+        #                 response_data_prop["name"] = k
+        #                 response_data_prop["required"] = k in parser.get_required(default=[k])
+        #                 assert isinstance(
+        #                     resp_data["data"], list
+        #                 ), "The response data type must be *list* if its HTTP response strategy is object."
+        #                 resp_data["data"].append(response_data_prop)
+        #             else:
+        #                 assert isinstance(
+        #                     resp_data["data"], dict
+        #                 ), "The response data type must be *dict* if its HTTP response strategy is not object."
+        #                 # resp_data["data"][k] = self._process_response_value(property_value=v, strategy=strategy)
+        #                 resp_data["data"][k] = strategy.generate_response(
+        #                     property_value=v,
+        #                     get_schema_parser_factory=ensure_get_schema_parser_factory,
+        #                     has_ref_callback=_YamlSchema.has_ref,
+        #                     get_ref_callback=_YamlSchema.get_schema_ref,
+        #                 )
+        #     return resp_data
 
-        def _initial_response_model_with_no_ref_value(resp_data: Dict[str, Any], _data: dict) -> Dict[str, Any]:
-            if strategy is ResponseStrategy.OBJECT:
-                # response_data_prop = self._process_response_value(property_value=_data, strategy=strategy)
-                response_data_prop = strategy.generate_response(
-                    property_value=_data,
-                    get_schema_parser_factory=ensure_get_schema_parser_factory,
-                    has_ref_callback=_YamlSchema.has_ref,
-                    get_ref_callback=_YamlSchema.get_schema_ref,
-                )
-                assert isinstance(response_data_prop, dict)
-                assert isinstance(
-                    resp_data["data"], list
-                ), "The response data type must be *list* if its HTTP response strategy is object."
-                resp_data["data"].append(response_data_prop)
-            else:
-                assert isinstance(
-                    resp_data["data"], dict
-                ), "The response data type must be *dict* if its HTTP response strategy is not object."
-                # resp_data["data"][0] = self._process_response_value(property_value=_data, strategy=strategy)
-                resp_data["data"][0] = strategy.generate_response(
-                    property_value=_data,
-                    get_schema_parser_factory=ensure_get_schema_parser_factory,
-                    has_ref_callback=_YamlSchema.has_ref,
-                    get_ref_callback=_YamlSchema.get_schema_ref,
-                )
-            return resp_data
+        # def _initial_response_model_with_no_ref_value(resp_data: Dict[str, Any], _data: dict) -> Dict[str, Any]:
+        #     if strategy is ResponseStrategy.OBJECT:
+        #         # response_data_prop = self._process_response_value(property_value=_data, strategy=strategy)
+        #         response_data_prop = strategy.generate_response(
+        #             property_value=_data,
+        #             get_schema_parser_factory=ensure_get_schema_parser_factory,
+        #             has_ref_callback=_YamlSchema.has_ref,
+        #             get_ref_callback=_YamlSchema.get_schema_ref,
+        #         )
+        #         assert isinstance(response_data_prop, dict)
+        #         assert isinstance(
+        #             resp_data["data"], list
+        #         ), "The response data type must be *list* if its HTTP response strategy is object."
+        #         resp_data["data"].append(response_data_prop)
+        #     else:
+        #         assert isinstance(
+        #             resp_data["data"], dict
+        #         ), "The response data type must be *dict* if its HTTP response strategy is not object."
+        #         # resp_data["data"][0] = self._process_response_value(property_value=_data, strategy=strategy)
+        #         resp_data["data"][0] = strategy.generate_response(
+        #             property_value=_data,
+        #             get_schema_parser_factory=ensure_get_schema_parser_factory,
+        #             has_ref_callback=_YamlSchema.has_ref,
+        #             get_ref_callback=_YamlSchema.get_schema_ref,
+        #         )
+        #     return resp_data
 
         assert self.parser.exist_in_response(status_code="200") is True
         status_200_response = self.parser.get_response(status_code="200")
@@ -253,7 +253,14 @@ class APIParser(BaseParser):
         #     }
         print(f"[DEBUG] status_200_response: {status_200_response}")
         if _YamlSchema.has_schema(status_200_response):
-            response_data = _initial_response_model_with_ref_value(response_data, status_200_response)
+            # response_data = _initial_response_model_with_ref_value(response_data, status_200_response)
+            response_data = strategy.process_response_from_reference(
+                init_response=response_data,
+                data=status_200_response,
+                get_schema_parser_factory=ensure_get_schema_parser_factory,
+                has_ref_callback=_YamlSchema.has_ref,
+                get_ref_callback=_YamlSchema.get_schema_ref,
+            )
             # response_data = strategy.process_response_from_reference(
             #     init_resp_data=response_data,
             #     data=status_200_response,
@@ -268,7 +275,14 @@ class APIParser(BaseParser):
             )
             response_schema = resp_parser.get_content(value_format=resp_value_format[0])
             if _YamlSchema.has_ref(response_schema):
-                response_data = _initial_response_model_with_ref_value(response_data, response_schema)
+                # response_data = _initial_response_model_with_ref_value(response_data, response_schema)
+                response_data = strategy.process_response_from_reference(
+                    init_response=response_data,
+                    data=response_schema,
+                    get_schema_parser_factory=ensure_get_schema_parser_factory,
+                    has_ref_callback=_YamlSchema.has_ref,
+                    get_ref_callback=_YamlSchema.get_schema_ref,
+                )
                 # response_data = strategy.process_response_from_reference(
                 #     init_resp_data=response_data,
                 #     data=status_200_response,
@@ -279,7 +293,14 @@ class APIParser(BaseParser):
             else:
                 print(f"[DEBUG] response_schema: {response_schema}")
                 # Data may '{}' or '{ "type": "integer", "title": "Id" }'
-                response_data = _initial_response_model_with_no_ref_value(response_data, response_schema)
+                # response_data = _initial_response_model_with_no_ref_value(response_data, response_schema)
+                response_data = strategy.process_response_from_data(
+                    init_response=response_data,
+                    data=response_schema,
+                    get_schema_parser_factory=ensure_get_schema_parser_factory,
+                    has_ref_callback=_YamlSchema.has_ref,
+                    get_ref_callback=_YamlSchema.get_schema_ref,
+                )
                 # response_data = strategy.process_response_from_data(
                 #     init_resp_data=response_data,
                 #     data=status_200_response,

--- a/pymock_api/model/openapi/config.py
+++ b/pymock_api/model/openapi/config.py
@@ -129,11 +129,10 @@ class OpenAPIDocumentConfig(Transferable):
         self._chk_version_and_load_parser(data)
 
         openapi_schema_parser = self.schema_parser_factory.entire_config(data=data)
+        set_component_definition(openapi_schema_parser)
         parser = OpenAPIDocumentConfigParser(parser=openapi_schema_parser)
         self.paths = cast(List[API], parser.process_paths(data_modal=API))
         self.tags = cast(List[Tag], parser.process_tags(data_modal=Tag))
-
-        set_component_definition(openapi_schema_parser)
 
         return self
 

--- a/test/unit_test/model/enums.py
+++ b/test/unit_test/model/enums.py
@@ -154,7 +154,6 @@ class TestResponseStrategy(EnumTestSuite):
                 ],
             ),
             (ResponseStrategy.STRING, {"type": "file"}, "random file output stream"),
-            # (ResponseStrategy.STRING, {"type": "object"}, "random object value"),
             # For object strategy
             (
                 ResponseStrategy.OBJECT,
@@ -192,11 +191,6 @@ class TestResponseStrategy(EnumTestSuite):
                 {"type": "file"},
                 {"name": "", "required": True, "type": "file", "format": None, "items": None},
             ),
-            # (
-            #     ResponseStrategy.OBJECT,
-            #     {"type": "object"},
-            #     {"name": "", "required": True, "type": "dict", "format": None, "items": None},
-            # ),
             # # Special data
             (
                 ResponseStrategy.STRING,

--- a/test/unit_test/model/enums.py
+++ b/test/unit_test/model/enums.py
@@ -152,24 +152,32 @@ class TestResponseStrategy(EnumTestSuite):
                 {"name": "", "required": True, "type": "dict", "format": None, "items": None},
             ),
             # # Special data
-            # (
-            #     ResponseStrategy.STRING,
-            #     {
-            #         "type": "object",
-            #         "additionalProperties": {
-            #             "type": "array",
-            #             "items": {"type": "string", "enum": ["IP_HOLDER", "PARTNER"]},
-            #         },
-            #     },
-            #     [
-            #         {
-            #             "id": "random integer value",
-            #             "name": "random string value",
-            #             "value1": "random string value",
-            #             "value2": "random string value",
-            #         }
-            #     ],
-            # ),
+            (
+                ResponseStrategy.STRING,
+                {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {"type": "string", "enum": ["TYPE_1", "TYPE_2"]},
+                    },
+                },
+                ["random string value"],
+            ),
+            (
+                ResponseStrategy.STRING,
+                {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/components/schemas/FooResponse",
+                    },
+                },
+                {
+                    "id": "random integer value",
+                    "name": "random string value",
+                    "value1": "random string value",
+                    "value2": "random string value",
+                },
+            ),
         ],
     )
     def test_generate_response_from_data(

--- a/test/unit_test/model/enums.py
+++ b/test/unit_test/model/enums.py
@@ -152,7 +152,24 @@ class TestResponseStrategy(EnumTestSuite):
                 {"name": "", "required": True, "type": "dict", "format": None, "items": None},
             ),
             # # Special data
-            # (ResponseStrategy.STRING, {"type": "object", "additionalProperties": {"type": "array", "items": {"type": "string", "enum": ["IP_HOLDER", "PARTNER"]}}}, [{"id": "random integer value", "name": "random string value", "value1": "random string value", "value2": "random string value"}]),
+            # (
+            #     ResponseStrategy.STRING,
+            #     {
+            #         "type": "object",
+            #         "additionalProperties": {
+            #             "type": "array",
+            #             "items": {"type": "string", "enum": ["IP_HOLDER", "PARTNER"]},
+            #         },
+            #     },
+            #     [
+            #         {
+            #             "id": "random integer value",
+            #             "name": "random string value",
+            #             "value1": "random string value",
+            #             "value2": "random string value",
+            #         }
+            #     ],
+            # ),
         ],
     )
     def test_generate_response_from_data(
@@ -186,7 +203,7 @@ class TestResponseStrategy(EnumTestSuite):
         resp = ut_enum.generate_response_from_data(
             resp_prop_data=test_response_data,
             get_schema_parser_factory=ensure_get_schema_parser_factory,
-            has_ref_callback=_YamlSchema.has_ref,
+            # has_ref_callback=_YamlSchema.has_ref,
             get_ref_callback=_YamlSchema.get_schema_ref,
         )
 

--- a/test/unit_test/model/enums.py
+++ b/test/unit_test/model/enums.py
@@ -74,6 +74,7 @@ class TestResponseStrategy(EnumTestSuite):
 
         # Run target function under test
         response_prop_data = strategy.generate_response(
+            init_response={},
             property_value=api_response_detail,
             get_schema_parser_factory=ensure_get_schema_parser_factory,
             has_ref_callback=_YamlSchema.has_ref,
@@ -153,7 +154,7 @@ class TestResponseStrategy(EnumTestSuite):
                 ],
             ),
             (ResponseStrategy.STRING, {"type": "file"}, "random file output stream"),
-            (ResponseStrategy.STRING, {"type": "object"}, "random object value"),
+            # (ResponseStrategy.STRING, {"type": "object"}, "random object value"),
             # For object strategy
             (
                 ResponseStrategy.OBJECT,
@@ -254,9 +255,10 @@ class TestResponseStrategy(EnumTestSuite):
 
         # Run target
         resp = ut_enum.generate_response_from_data(
+            init_response=ut_enum.initial_response_data(),
             resp_prop_data=test_response_data,
             get_schema_parser_factory=ensure_get_schema_parser_factory,
-            # has_ref_callback=_YamlSchema.has_ref,
+            has_ref_callback=_YamlSchema.has_ref,
             get_ref_callback=_YamlSchema.get_schema_ref,
         )
 

--- a/test/unit_test/model/enums.py
+++ b/test/unit_test/model/enums.py
@@ -203,6 +203,16 @@ class TestResponseStrategy(EnumTestSuite):
                 {
                     "type": "object",
                     "additionalProperties": {
+                        "type": "string",
+                    },
+                },
+                "random string value",
+            ),
+            (
+                ResponseStrategy.STRING,
+                {
+                    "type": "object",
+                    "additionalProperties": {
                         "type": "array",
                         "items": {"type": "string", "enum": ["TYPE_1", "TYPE_2"]},
                     },

--- a/test/unit_test/model/enums.py
+++ b/test/unit_test/model/enums.py
@@ -11,6 +11,12 @@ from pymock_api.model.enums import (
     ResponseStrategy,
     set_loading_function,
 )
+from pymock_api.model.openapi._base import (
+    _YamlSchema,
+    ensure_get_schema_parser_factory,
+    set_component_definition,
+)
+from pymock_api.model.openapi._schema_parser import OpenAPIV3SchemaParser
 
 
 def test_set_loading_function():
@@ -48,6 +54,145 @@ class TestResponseStrategy(EnumTestSuite):
     )
     def test_to_enum(self, value: Any, enum_obj: Type[ResponseStrategy]):
         super().test_to_enum(value, enum_obj)
+
+    @pytest.mark.parametrize(
+        ("ut_enum", "expected_type"),
+        [
+            (ResponseStrategy.STRING, str),
+            (ResponseStrategy.FILE, str),
+            (ResponseStrategy.OBJECT, dict),
+        ],
+    )
+    def test_generate_empty_response(self, ut_enum: ResponseStrategy, expected_type: type):
+        empty_resp = ut_enum.generate_empty_response()
+        assert isinstance(empty_resp, expected_type)
+
+    @pytest.mark.parametrize(
+        ("ut_enum", "expected_type"),
+        [
+            (ResponseStrategy.STRING, str),
+            (ResponseStrategy.FILE, str),
+            (ResponseStrategy.OBJECT, dict),
+        ],
+    )
+    def test_generate_response_from_reference(self, ut_enum: ResponseStrategy, expected_type: type):
+        resp = ut_enum.generate_response_from_reference({"response reference data": {}})
+        assert isinstance(resp, expected_type)
+
+    @pytest.mark.parametrize(
+        ("ut_enum", "test_response_data", "expected_value"),
+        [
+            # # General data
+            (ResponseStrategy.STRING, {"type": "string"}, "random string value"),
+            (ResponseStrategy.FILE, {"type": "string"}, "random string value"),
+            (
+                ResponseStrategy.OBJECT,
+                {"type": "string"},
+                {"name": "", "required": True, "type": "str", "format": None, "items": None},
+            ),
+            # # Each different type as general data
+            # For string strategy (the process details of string and file are the same, so it only test one of them)
+            (ResponseStrategy.STRING, {"type": "integer"}, "random integer value"),
+            (ResponseStrategy.STRING, {"type": "number"}, "random integer value"),
+            (ResponseStrategy.STRING, {"type": "boolean"}, "random boolean value"),
+            (
+                ResponseStrategy.STRING,
+                {"type": "array", "items": {"$ref": "#/components/schemas/FooResponse"}},
+                [
+                    {
+                        "id": "random integer value",
+                        "name": "random string value",
+                        "value1": "random string value",
+                        "value2": "random string value",
+                    }
+                ],
+            ),
+            (ResponseStrategy.STRING, {"type": "file"}, "random file output stream"),
+            (ResponseStrategy.STRING, {"type": "object"}, "random object value"),
+            # For object strategy
+            (
+                ResponseStrategy.OBJECT,
+                {"type": "integer"},
+                {"name": "", "required": True, "type": "int", "format": None, "items": None},
+            ),
+            (
+                ResponseStrategy.OBJECT,
+                {"type": "number"},
+                {"name": "", "required": True, "type": "int", "format": None, "items": None},
+            ),
+            (
+                ResponseStrategy.OBJECT,
+                {"type": "boolean"},
+                {"name": "", "required": True, "type": "bool", "format": None, "items": None},
+            ),
+            (
+                ResponseStrategy.OBJECT,
+                {"type": "array", "items": {"$ref": "#/components/schemas/FooResponse"}},
+                {
+                    "name": "",
+                    "required": True,
+                    "type": "list",
+                    "format": None,
+                    "items": [
+                        {"name": "id", "required": True, "type": "int"},
+                        {"name": "name", "required": True, "type": "str"},
+                        {"name": "value1", "required": True, "type": "str"},
+                        {"name": "value2", "required": True, "type": "str"},
+                    ],
+                },
+            ),
+            (
+                ResponseStrategy.OBJECT,
+                {"type": "file"},
+                {"name": "", "required": True, "type": "file", "format": None, "items": None},
+            ),
+            (
+                ResponseStrategy.OBJECT,
+                {"type": "object"},
+                {"name": "", "required": True, "type": "dict", "format": None, "items": None},
+            ),
+            # # Special data
+            # (ResponseStrategy.STRING, {"type": "object", "additionalProperties": {"type": "array", "items": {"type": "string", "enum": ["IP_HOLDER", "PARTNER"]}}}, [{"id": "random integer value", "name": "random string value", "value1": "random string value", "value2": "random string value"}]),
+        ],
+    )
+    def test_generate_response_from_data(
+        self, ut_enum: ResponseStrategy, test_response_data: dict, expected_value: str
+    ):
+        # Pre-process
+        if test_response_data["type"] == "array":
+            set_component_definition(
+                OpenAPIV3SchemaParser(
+                    data={
+                        "components": {
+                            "schemas": {
+                                "FooResponse": {
+                                    "type": "object",
+                                    "required": ["id"],
+                                    "properties": {
+                                        "id": {"type": "integer", "format": "int64"},
+                                        "name": {"type": "string"},
+                                        "value1": {"type": "string"},
+                                        "value2": {"type": "string"},
+                                    },
+                                    "title": "FooResponse",
+                                },
+                            },
+                        },
+                    }
+                )
+            )
+
+        # Run target
+        resp = ut_enum.generate_response_from_data(
+            resp_prop_data=test_response_data,
+            get_schema_parser_factory=ensure_get_schema_parser_factory,
+            has_ref_callback=_YamlSchema.has_ref,
+            get_ref_callback=_YamlSchema.get_schema_ref,
+        )
+
+        # Verify
+        assert resp
+        assert resp == expected_value
 
 
 class TestConfigLoadingOrder(EnumTestSuite):

--- a/test/unit_test/model/enums.py
+++ b/test/unit_test/model/enums.py
@@ -234,6 +234,56 @@ class TestResponseStrategy(EnumTestSuite):
                     "value2": "random string value",
                 },
             ),
+            (
+                ResponseStrategy.OBJECT,
+                {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string",
+                    },
+                },
+                {"name": "", "required": True, "type": "str", "format": None, "items": None},
+            ),
+            (
+                ResponseStrategy.OBJECT,
+                {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {"type": "string", "enum": ["TYPE_1", "TYPE_2"]},
+                    },
+                },
+                {
+                    "name": "",
+                    "required": True,
+                    "type": "list",
+                    "format": None,
+                    "items": [
+                        {"name": "", "required": True, "type": "str"},
+                    ],
+                },
+            ),
+            (
+                ResponseStrategy.OBJECT,
+                {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/components/schemas/FooResponse",
+                    },
+                },
+                {
+                    "name": "",
+                    "required": True,
+                    "type": "list",
+                    "format": None,
+                    "items": [
+                        {"name": "id", "required": True, "type": "int"},
+                        {"name": "name", "required": True, "type": "str"},
+                        {"name": "value1", "required": True, "type": "str"},
+                        {"name": "value2", "required": True, "type": "str"},
+                    ],
+                },
+            ),
         ],
     )
     def test_generate_response_from_data(

--- a/test/unit_test/model/enums.py
+++ b/test/unit_test/model/enums.py
@@ -192,11 +192,11 @@ class TestResponseStrategy(EnumTestSuite):
                 {"type": "file"},
                 {"name": "", "required": True, "type": "file", "format": None, "items": None},
             ),
-            (
-                ResponseStrategy.OBJECT,
-                {"type": "object"},
-                {"name": "", "required": True, "type": "dict", "format": None, "items": None},
-            ),
+            # (
+            #     ResponseStrategy.OBJECT,
+            #     {"type": "object"},
+            #     {"name": "", "required": True, "type": "dict", "format": None, "items": None},
+            # ),
             # # Special data
             (
                 ResponseStrategy.STRING,
@@ -259,7 +259,7 @@ class TestResponseStrategy(EnumTestSuite):
                     "type": "list",
                     "format": None,
                     "items": [
-                        {"name": "", "required": True, "type": "str"},
+                        {"name": "", "required": True, "type": "str", "format": None, "items": None},
                     ],
                 },
             ),
@@ -271,18 +271,12 @@ class TestResponseStrategy(EnumTestSuite):
                         "$ref": "#/components/schemas/FooResponse",
                     },
                 },
-                {
-                    "name": "",
-                    "required": True,
-                    "type": "list",
-                    "format": None,
-                    "items": [
-                        {"name": "id", "required": True, "type": "int"},
-                        {"name": "name", "required": True, "type": "str"},
-                        {"name": "value1", "required": True, "type": "str"},
-                        {"name": "value2", "required": True, "type": "str"},
-                    ],
-                },
+                [
+                    {"name": "id", "required": True, "type": "int", "format": None, "items": None},
+                    {"name": "name", "required": False, "type": "str", "format": None, "items": None},
+                    {"name": "value1", "required": False, "type": "str", "format": None, "items": None},
+                    {"name": "value2", "required": False, "type": "str", "format": None, "items": None},
+                ],
             ),
         ],
     )

--- a/test/unit_test/model/openapi/inner_parser.py
+++ b/test/unit_test/model/openapi/inner_parser.py
@@ -23,7 +23,6 @@ from ._test_case import (
     OPENAPI_API_PARAMETERS_JSON_FOR_API,
     OPENAPI_API_PARAMETERS_LIST_JSON_FOR_API,
     OPENAPI_API_RESPONSES_FOR_API,
-    OPENAPI_API_RESPONSES_PROPERTY_FOR_API,
     ensure_load_openapi_test_cases,
 )
 
@@ -174,38 +173,3 @@ class TestAPIParser:
                                 ]
                             else:
                                 assert item_value == "empty value"
-
-    @pytest.mark.parametrize(
-        ("strategy", "api_response_detail", "entire_config"), OPENAPI_API_RESPONSES_PROPERTY_FOR_API
-    )
-    def test__process_response_value(
-        self, parser: Type[APIParser], strategy: ResponseStrategy, api_response_detail: dict, entire_config: dict
-    ):
-        # Pre-process
-        set_component_definition(OpenAPIV2SchemaParser(data=entire_config))
-
-        # Run target function under test
-        parser_instance = parser(parser=DummyPathSchemaParser({}))
-        response_prop_data = parser_instance._process_response_value(
-            property_value=api_response_detail, strategy=strategy
-        )
-
-        # Verify
-        if strategy is ResponseStrategy.OBJECT:
-            assert response_prop_data and isinstance(response_prop_data, dict)
-            for resp_k, resp_v in response_prop_data.items():
-                assert resp_k in ["name", "required", "type", "format", "items", "FIXME"]
-        else:
-            assert response_prop_data and isinstance(response_prop_data, (str, list))
-            if response_prop_data and isinstance(response_prop_data, str):
-                assert response_prop_data in [
-                    "random string value",
-                    "random integer value",
-                    "random boolean value",
-                    "random file output stream",
-                    "FIXME: Handle the reference",
-                ]
-            else:
-                for item in response_prop_data:
-                    for item_value in item.values():
-                        assert item_value in ["random string value", "random integer value", "random boolean value"]


### PR DESCRIPTION
### _Target_

* Support parsing JavaScript data type ``object`` in response part configuration.
* Fix some major issues.
    * Cannot run tool finely because the global variable still not initial yet.
    * Doesn't cover enough response data content type so that it cannot run parsing process at response part finely.


### _Effecting Scope_

* Nothing breaking changes.


### _Description_

* Support parsing the JavaScript data type ``object`` at response part OpenAPI document configuration (includes for each values of enum ``ResponseStrategy``).
* Fix major issues which would cause the tool cannot work.
    * Modify the process initials the global variable about the OpenAPI configuration component (or definition section in OpenAPI version 2) section.
    * Extract the response data content type as a single variable and add one more type to let it could run finely.
