### PR TITLE
🎉🎊🍾 [New Feature] Support nested data with `dict` type in configuration and improve error message to be more clear in fail test

### DIFF
--- a/pymock_api/model/api_config/_base.py
+++ b/pymock_api/model/api_config/_base.py
@@ -184,6 +184,8 @@ class _HasItemsPropConfig(_Config, _Checkable, ABC):
     items: Optional[List["_HasItemsPropConfig"]] = None
 
     def _compare(self, other: "_HasItemsPropConfig") -> bool:
+        if self.items and other.items:
+            return len(self.items) == len(other.items)
         return self.items == other.items
 
     def __post_init__(self) -> None:

--- a/pymock_api/model/api_config/_base.py
+++ b/pymock_api/model/api_config/_base.py
@@ -184,9 +184,32 @@ class _HasItemsPropConfig(_Config, _Checkable, ABC):
     items: Optional[List["_HasItemsPropConfig"]] = None
 
     def _compare(self, other: "_HasItemsPropConfig") -> bool:
+        items_prop_is_same: bool = True
+
+        # Compare property *items* size
         if self.items and other.items:
-            return len(self.items) == len(other.items)
-        return self.items == other.items
+            items_prop_is_same = len(self.items) == len(other.items)
+
+        # Compare property *items* details
+        for item in self.items or []:
+            same_name_other_item = list(
+                filter(lambda i: self._find_same_key_item_to_compare(self_item=item, other_item=i), other.items or [])
+            )
+            if not same_name_other_item:
+                items_prop_is_same = False
+                break
+            assert len(same_name_other_item) == 1
+            if item != same_name_other_item[0]:
+                items_prop_is_same = False
+                break
+
+        return items_prop_is_same
+
+    @abstractmethod
+    def _find_same_key_item_to_compare(
+        self, self_item: "_HasItemsPropConfig", other_item: "_HasItemsPropConfig"
+    ) -> bool:
+        pass
 
     def __post_init__(self) -> None:
         if self.items is not None:

--- a/pymock_api/model/api_config/apis/_property.py
+++ b/pymock_api/model/api_config/apis/_property.py
@@ -15,18 +15,6 @@ class BaseProperty(_HasItemsPropConfig, ABC):
     items: Optional[List[IteratorItem]] = None  # type: ignore[assignment]
 
     def _compare(self, other: "BaseProperty") -> bool:  # type: ignore[override]
-        # Compare property *items* details
-        items_prop_is_same: bool = True
-        for item in self.items or []:
-            same_name_other_item = list(filter(lambda i: item.name == i.name, other.items or []))
-            if not same_name_other_item:
-                items_prop_is_same = False
-                break
-            assert len(same_name_other_item) == 1
-            if item != same_name_other_item[0]:
-                items_prop_is_same = False
-                break
-
         return (
             self.name == other.name
             and self.required == other.required
@@ -34,8 +22,10 @@ class BaseProperty(_HasItemsPropConfig, ABC):
             and self.value_format == other.value_format
             # Compare property *items*
             and super()._compare(other)
-            and items_prop_is_same
         )
+
+    def _find_same_key_item_to_compare(self, self_item: "BaseProperty", other_item: "BaseProperty") -> bool:  # type: ignore[override]
+        return self_item.name == other_item.name
 
     def _item_type(self) -> Type["IteratorItem"]:
         return IteratorItem

--- a/pymock_api/model/api_config/apis/_property.py
+++ b/pymock_api/model/api_config/apis/_property.py
@@ -23,13 +23,10 @@ class BaseProperty(_HasItemsPropConfig, ABC):
                 items_prop_is_same = False
                 break
             assert len(same_name_other_item) == 1
-            # print(f"[DEBUG in BaseProperty._compare] item: {item}")
-            # print(f"[DEBUG in BaseProperty._compare] same_name_other_item: {same_name_other_item}")
             if item != same_name_other_item[0]:
                 items_prop_is_same = False
                 break
 
-        # print(f"[DEBUG in BaseProperty._compare] items_prop_is_same: {items_prop_is_same}")
         return (
             self.name == other.name
             and self.required == other.required

--- a/pymock_api/model/api_config/apis/_property.py
+++ b/pymock_api/model/api_config/apis/_property.py
@@ -15,12 +15,29 @@ class BaseProperty(_HasItemsPropConfig, ABC):
     items: Optional[List[IteratorItem]] = None  # type: ignore[assignment]
 
     def _compare(self, other: "BaseProperty") -> bool:  # type: ignore[override]
+        # Compare property *items* details
+        items_prop_is_same: bool = True
+        for item in self.items or []:
+            same_name_other_item = list(filter(lambda i: item.name == i.name, other.items or []))
+            if not same_name_other_item:
+                items_prop_is_same = False
+                break
+            assert len(same_name_other_item) == 1
+            # print(f"[DEBUG in BaseProperty._compare] item: {item}")
+            # print(f"[DEBUG in BaseProperty._compare] same_name_other_item: {same_name_other_item}")
+            if item != same_name_other_item[0]:
+                items_prop_is_same = False
+                break
+
+        # print(f"[DEBUG in BaseProperty._compare] items_prop_is_same: {items_prop_is_same}")
         return (
             self.name == other.name
             and self.required == other.required
             and self.value_type == other.value_type
             and self.value_format == other.value_format
+            # Compare property *items*
             and super()._compare(other)
+            and items_prop_is_same
         )
 
     def _item_type(self) -> Type["IteratorItem"]:

--- a/pymock_api/model/api_config/item.py
+++ b/pymock_api/model/api_config/item.py
@@ -23,13 +23,10 @@ class IteratorItem(_HasItemsPropConfig):
                 items_prop_is_same = False
                 break
             assert len(same_name_other_item) == 1
-            # print(f"[DEBUG in IteratorItem._compare] item: {item}")
-            # print(f"[DEBUG in IteratorItem._compare] same_name_other_item: {same_name_other_item}")
             if item != same_name_other_item[0]:
                 items_prop_is_same = False
                 break
 
-        # print(f"[DEBUG in IteratorItem._compare] items_prop_is_same: {items_prop_is_same}")
         return (
             self.name == other.name
             and self.required == other.required

--- a/pymock_api/model/api_config/item.py
+++ b/pymock_api/model/api_config/item.py
@@ -15,11 +15,28 @@ class IteratorItem(_HasItemsPropConfig):
     _absolute_key: str = field(init=False, repr=False)
 
     def _compare(self, other: "IteratorItem") -> bool:  # type: ignore[override]
+        # Compare property *items* details
+        items_prop_is_same: bool = True
+        for item in self.items or []:
+            same_name_other_item = list(filter(lambda i: item.name == i.name, other.items or []))
+            if not same_name_other_item:
+                items_prop_is_same = False
+                break
+            assert len(same_name_other_item) == 1
+            # print(f"[DEBUG in IteratorItem._compare] item: {item}")
+            # print(f"[DEBUG in IteratorItem._compare] same_name_other_item: {same_name_other_item}")
+            if item != same_name_other_item[0]:
+                items_prop_is_same = False
+                break
+
+        # print(f"[DEBUG in IteratorItem._compare] items_prop_is_same: {items_prop_is_same}")
         return (
             self.name == other.name
             and self.required == other.required
             and self.value_type == other.value_type
+            # Compare property *items*
             and super()._compare(other)
+            and items_prop_is_same
         )
 
     def _item_type(self) -> Type["IteratorItem"]:

--- a/pymock_api/model/api_config/item.py
+++ b/pymock_api/model/api_config/item.py
@@ -15,26 +15,16 @@ class IteratorItem(_HasItemsPropConfig):
     _absolute_key: str = field(init=False, repr=False)
 
     def _compare(self, other: "IteratorItem") -> bool:  # type: ignore[override]
-        # Compare property *items* details
-        items_prop_is_same: bool = True
-        for item in self.items or []:
-            same_name_other_item = list(filter(lambda i: item.name == i.name, other.items or []))
-            if not same_name_other_item:
-                items_prop_is_same = False
-                break
-            assert len(same_name_other_item) == 1
-            if item != same_name_other_item[0]:
-                items_prop_is_same = False
-                break
-
         return (
             self.name == other.name
             and self.required == other.required
             and self.value_type == other.value_type
             # Compare property *items*
             and super()._compare(other)
-            and items_prop_is_same
         )
+
+    def _find_same_key_item_to_compare(self, self_item: "IteratorItem", other_item: "IteratorItem") -> bool:  # type: ignore[override]
+        return self_item.name == other_item.name
 
     def _item_type(self) -> Type["IteratorItem"]:
         return IteratorItem

--- a/pymock_api/model/api_config/template/_load.py
+++ b/pymock_api/model/api_config/template/_load.py
@@ -122,10 +122,7 @@ class TemplateConfigLoaderByScanFile(_BaseTemplateConfigLoader):
             if os.path.isdir(path):
                 self._iterate_files_to_deserialize_template_config(path)
             else:
-                assert os.path.isfile(path) is True
-                if fnmatch.fnmatch(path, self._template_config_opts._config_file_format):
-                    # Doesn't have tag, it's config
-                    self._deserialize_and_set_template_config(path)
+                self._use_specific_file_to_deserialize_template_config(path)
 
     def _iterate_files_to_deserialize_template_config(self, path: str) -> None:
         # Has tag as directory
@@ -151,6 +148,12 @@ class TemplateConfigLoaderByScanFile(_BaseTemplateConfigLoader):
             for path_with_tag in glob.glob(str(pathlib.Path(path, self._template_config_opts._config_file_format))):
                 # In the tag directory, it's config
                 self._deserialize_and_set_template_config(path_with_tag)
+
+    def _use_specific_file_to_deserialize_template_config(self, path: str) -> None:
+        # Doesn't have tag, it's config
+        assert os.path.isfile(path) is True
+        if fnmatch.fnmatch(path, self._template_config_opts._config_file_format):
+            self._deserialize_and_set_template_config(path)
 
 
 class TemplateConfigLoaderByApply(_BaseTemplateConfigLoader):

--- a/pymock_api/model/api_config/template/_load.py
+++ b/pymock_api/model/api_config/template/_load.py
@@ -70,10 +70,6 @@ class _BaseTemplateConfigLoader:
         args = {
             "path": path,
         }
-        # Get parent config
-        # Set the current config (which is child-config) into the parent config, e.g., set the HTTP config
-        # *HTTP A* into MockAPI config *API A*, doesn't set into MockAPI config *API B*.
-        # parent_config = self._get_parent_config()
         self._template_config_opts._set_template_config(config, **args)
 
     def _deserialize_template_config(self, path: str) -> Optional[_Config]:

--- a/pymock_api/model/api_config/template/_load.py
+++ b/pymock_api/model/api_config/template/_load.py
@@ -120,36 +120,37 @@ class TemplateConfigLoaderByScanFile(_BaseTemplateConfigLoader):
             all_paths.remove(api_config_path)
         for path in all_paths:
             if os.path.isdir(path):
-                # Has tag as directory
-                if hasattr(self._template_config_opts, "config_path"):
-                    # NOTE: ``get the specific file directly when *self._template_config_opts* is NOT *MockAPIs*``
-                    # If it's setting the configuration like *HTTP*, *HTTP request* or something else which is for THE
-                    # SPECIFIC one *MockAPI* data model, it should also use THE SPECIFIC one configuration file to set
-                    # its request or response.
-                    file_name_head = self._template_config_opts.config_path.split("-")[0]
-                    config_path = pathlib.Path(
-                        path, self._template_config_opts._config_file_format.replace("**", file_name_head)
-                    )
-                    if config_path.exists():
-                        self._deserialize_and_set_template_config(str(config_path))
-                else:
-                    # NOTE: ``only iterates all files when *self._template_config_opts* is *MockAPIs*``
-                    # Only iterate all files to get its content and convert it as configuration when the current data
-                    # model is *MockAPIs*. Reason is easy and clear, please consider it also divide the config *HTTP*
-                    # or *HTTP request* or something else, and it has multiple APIs. It may iterate other files which
-                    # are not relative with it at all.
-                    # Please refer to test data *divide_api_http_response_with_nested_data+has_tag_include_template*
-                    # to clear the usage scenario.
-                    for path_with_tag in glob.glob(
-                        str(pathlib.Path(path, self._template_config_opts._config_file_format))
-                    ):
-                        # In the tag directory, it's config
-                        self._deserialize_and_set_template_config(path_with_tag)
+                self._iterate_files_to_deserialize_template_config(path)
             else:
                 assert os.path.isfile(path) is True
                 if fnmatch.fnmatch(path, self._template_config_opts._config_file_format):
                     # Doesn't have tag, it's config
                     self._deserialize_and_set_template_config(path)
+
+    def _iterate_files_to_deserialize_template_config(self, path: str) -> None:
+        # Has tag as directory
+        if hasattr(self._template_config_opts, "config_path"):
+            # NOTE: ``get the specific file directly when *self._template_config_opts* is NOT *MockAPIs*``
+            # If it's setting the configuration like *HTTP*, *HTTP request* or something else which is for THE
+            # SPECIFIC one *MockAPI* data model, it should also use THE SPECIFIC one configuration file to set
+            # its request or response.
+            file_name_head = self._template_config_opts.config_path.split("-")[0]
+            config_path = pathlib.Path(
+                path, self._template_config_opts._config_file_format.replace("**", file_name_head)
+            )
+            if config_path.exists():
+                self._deserialize_and_set_template_config(str(config_path))
+        else:
+            # NOTE: ``only iterates all files when *self._template_config_opts* is *MockAPIs*``
+            # Only iterate all files to get its content and convert it as configuration when the current data
+            # model is *MockAPIs*. Reason is easy and clear, please consider it also divide the config *HTTP*
+            # or *HTTP request* or something else, and it has multiple APIs. It may iterate other files which
+            # are not relative with it at all.
+            # Please refer to test data *divide_api_http_response_with_nested_data+has_tag_include_template*
+            # to clear the usage scenario.
+            for path_with_tag in glob.glob(str(pathlib.Path(path, self._template_config_opts._config_file_format))):
+                # In the tag directory, it's config
+                self._deserialize_and_set_template_config(path_with_tag)
 
 
 class TemplateConfigLoaderByApply(_BaseTemplateConfigLoader):

--- a/pymock_api/model/enums.py
+++ b/pymock_api/model/enums.py
@@ -423,6 +423,8 @@ class ResponseStrategy(Enum):
                             "items": None,
                         }
                 else:
+                    # FIXME: it should focus on processing the config data which data structure is for one specific
+                    #  column, not for entire object.
                     # Process non-reference
                     resp = self.process_response_from_reference(
                         init_response={"strategy": ResponseStrategy.OBJECT, "data": []},

--- a/pymock_api/model/enums.py
+++ b/pymock_api/model/enums.py
@@ -65,7 +65,6 @@ class ResponseStrategy(Enum):
         response_schema_ref: dict,
         get_schema_parser_factory: Callable,
         empty_body_key: str = "",
-        not_set_init_resp: bool = False,
     ) -> dict:
         parser = get_schema_parser_factory().object(response_schema_ref)
         response_schema_properties: Optional[dict] = parser.get_properties(default={})

--- a/pymock_api/model/enums.py
+++ b/pymock_api/model/enums.py
@@ -52,14 +52,14 @@ class ResponseStrategy(Enum):
         init_response: dict,
         data: dict,
         get_schema_parser_factory: Callable,
-        parse_from_schema: bool = True,
     ) -> dict:
-        if parse_from_schema:
-            response_schema_ref = get_schema_parser_factory().reference_object().get_schema_ref(data)
-        else:
-            response_schema_ref = data
+        response_schema_ref = get_schema_parser_factory().reference_object().get_schema_ref(data)
         print(f"[DEBUG in process_response_from_reference] data: {data}")
-        return self._process_reference_object(init_response, response_schema_ref, get_schema_parser_factory)
+        return self._process_reference_object(
+            init_response=init_response,
+            response_schema_ref=response_schema_ref,
+            get_schema_parser_factory=get_schema_parser_factory,
+        )
 
     def _process_reference_object(
         self,
@@ -511,7 +511,6 @@ class ResponseStrategy(Enum):
                         init_response={"strategy": ResponseStrategy.OBJECT, "data": []},
                         data=data,
                         get_schema_parser_factory=get_schema_parser_factory,
-                        parse_from_schema=False,
                     )
                     print(
                         f'[DEBUG in _handle_object_type_value_with_object_strategy] before *"additionalProperties" in data.keys()* data: {data}'

--- a/pymock_api/model/enums.py
+++ b/pymock_api/model/enums.py
@@ -55,7 +55,7 @@ class ResponseStrategy(Enum):
     ) -> dict:
         response_schema_ref = get_schema_parser_factory().reference_object().get_schema_ref(data)
         parser = get_schema_parser_factory().object(response_schema_ref)
-        response_schema_properties: Optional[dict] = parser.get_properties(default=None)
+        response_schema_properties: Optional[dict] = parser.get_properties(default={})
         if response_schema_properties:
             for k, v in response_schema_properties.items():
                 print(f"[DEBUG in process_response_from_reference] v: {v}")
@@ -121,12 +121,30 @@ class ResponseStrategy(Enum):
         if not property_value:
             return self._generate_empty_response()
         print(f"[DEBUG in _generate_response] property_value: {property_value}")
-        if get_schema_parser_factory().reference_object().has_ref(property_value):
-            return self._generate_response_from_data(
+        ref_schema = get_schema_parser_factory().reference_object().has_ref(property_value)
+        if ref_schema:
+            # if ref_schema == "ref":
+            #     resp = self.process_response_from_reference(
+            #         init_response=init_response,
+            #         data=property_value,
+            #         get_schema_parser_factory=get_schema_parser_factory,
+            #     )
+            #     print(f"[DEBUG in _generate_response] resp: {resp}")
+            #     return resp
+            # else:
+            # resp_1 = self._generate_response_from_data(
+            #     init_response=init_response,
+            #     resp_prop_data=get_schema_parser_factory().reference_object().get_schema_ref(property_value),
+            #     get_schema_parser_factory=get_schema_parser_factory,
+            # )
+            # print(f"[DEBUG in _generate_response] resp_1: {resp_1}")
+            resp_2 = self.process_response_from_reference(
                 init_response=init_response,
-                resp_prop_data=get_schema_parser_factory().reference_object().get_schema_ref(property_value),
+                data=property_value,
                 get_schema_parser_factory=get_schema_parser_factory,
             )
+            print(f"[DEBUG in _generate_response] resp_2: {resp_2}")
+            return resp_2
         else:
             return self._generate_response_from_data(
                 init_response=init_response,
@@ -328,7 +346,9 @@ class ResponseStrategy(Enum):
                         "items": None,
                     }
             else:
-                raise NotImplementedError("It should parse the configuration which is entire object.")
+                raise NotImplementedError(
+                    "It should re-consider the parsing logic about handle object type config with object strategy."
+                )
 
         def _handle_other_types_value_with_object_strategy(v_type: str) -> dict:
             return {

--- a/pymock_api/model/enums.py
+++ b/pymock_api/model/enums.py
@@ -94,7 +94,6 @@ class ResponseStrategy(Enum):
                         init_response=init_response,
                         property_value=v,
                         get_schema_parser_factory=get_schema_parser_factory,
-                        property_key=k,
                     )
                 print(f"[DEBUG in process_response_from_reference] response_config: {response_config}")
                 if self is ResponseStrategy.OBJECT:
@@ -172,7 +171,6 @@ class ResponseStrategy(Enum):
         init_response: dict,
         property_value: dict,
         get_schema_parser_factory: Callable,
-        property_key: str = "",
     ) -> Union[str, list, dict]:
         if not property_value:
             return self._generate_empty_response()
@@ -182,61 +180,13 @@ class ResponseStrategy(Enum):
             print(f"[DEBUG in _generate_response] before it have ref_schema: {ref_schema}")
             print(f"[DEBUG in _generate_response] before it have init_response: {init_response}")
             print(f"[DEBUG in _generate_response] before it have resp_2: {property_value}")
-            # if ref_schema == "ref":
-            #     resp = self.process_response_from_reference(
-            #         init_response=init_response,
-            #         data=property_value,
-            #         get_schema_parser_factory=get_schema_parser_factory,
-            #     )
-            #     print(f"[DEBUG in _generate_response] resp: {resp}")
-            #     return resp
-            # else:
-            # if ref_schema == "ref":
-            #     resp_1 = self._generate_response_from_data(
-            #         init_response=init_response,
-            #         resp_prop_data=property_value,
-            #         get_schema_parser_factory=get_schema_parser_factory,
-            #     )
-            # else:
             # # Currently solution
             resp_1 = self._generate_response_from_data(
                 init_response=init_response,
                 resp_prop_data=get_schema_parser_factory().reference_object().get_schema_ref(property_value),
                 get_schema_parser_factory=get_schema_parser_factory,
             )
-            # # test ...
-
-            # resp_1 = self._process_reference_object(
-            #     init_response=init_response,
-            #     response_schema_ref=get_schema_parser_factory().reference_object().get_schema_ref(property_value),
-            #     get_schema_parser_factory=get_schema_parser_factory,
-            #     empty_body_key=property_key,
-            # )
-            print(f"[DEBUG in _generate_response] resp_1: {resp_1}")
-            # resp_2 = self.process_response_from_reference(
-            #     init_response=init_response,
-            #     data=property_value,
-            #     get_schema_parser_factory=get_schema_parser_factory,
-            # )
-            # print(f"[DEBUG in _generate_response] resp_2: {resp_2}")
-            # Find the specific element and return it
-            # for e in resp_2["data"]:
-            #     print(f"[DEBUG in _generate_response] e: {e}")
-            #     if e["name"] in property_value[f"${ref_schema}"]:
-            #         assert isinstance(e, dict)
-            #         print(f"[DEBUG in _generate_response] under resp_2 e: {e}")
-            #         return e
-            # Note:
-            # Data format should be like:
-            # {
-            #      "name": "",
-            #      "required": _Default_Required.empty,
-            #      "type": None,
-            #      "format": None,
-            #      "items": [],
-            # }
             return resp_1
-            # assert False
         else:
             resp_from_data = self._generate_response_from_data(
                 init_response=init_response,

--- a/pymock_api/model/enums.py
+++ b/pymock_api/model/enums.py
@@ -175,26 +175,16 @@ class ResponseStrategy(Enum):
         if not property_value:
             return self._generate_empty_response()
         print(f"[DEBUG in _generate_response] property_value: {property_value}")
-        ref_schema = get_schema_parser_factory().reference_object().has_ref(property_value)
-        if ref_schema:
-            print(f"[DEBUG in _generate_response] before it have ref_schema: {ref_schema}")
-            print(f"[DEBUG in _generate_response] before it have init_response: {init_response}")
-            print(f"[DEBUG in _generate_response] before it have resp_2: {property_value}")
-            # # Currently solution
-            resp_1 = self._generate_response_from_data(
-                init_response=init_response,
-                resp_prop_data=get_schema_parser_factory().reference_object().get_schema_ref(property_value),
-                get_schema_parser_factory=get_schema_parser_factory,
-            )
-            return resp_1
+        print(f"[DEBUG in _generate_response] before it have init_response: {init_response}")
+        if get_schema_parser_factory().reference_object().has_ref(property_value):
+            resp_prop_data = get_schema_parser_factory().reference_object().get_schema_ref(property_value)
         else:
-            resp_from_data = self._generate_response_from_data(
-                init_response=init_response,
-                resp_prop_data=property_value,
-                get_schema_parser_factory=get_schema_parser_factory,
-            )
-            print(f"[DEBUG in _generate_response] resp_from_data: {resp_from_data}")
-            return resp_from_data
+            resp_prop_data = property_value
+        return self._generate_response_from_data(
+            init_response=init_response,
+            resp_prop_data=resp_prop_data,
+            get_schema_parser_factory=get_schema_parser_factory,
+        )
 
     def _generate_empty_response(self) -> Union[str, Dict[str, Any]]:
         if self is ResponseStrategy.OBJECT:

--- a/pymock_api/model/enums.py
+++ b/pymock_api/model/enums.py
@@ -345,20 +345,8 @@ class ResponseStrategy(Enum):
                 else:
                     raise NotImplementedError
 
-            has_ref = get_schema_parser_factory().reference_object().has_ref(data)
-
-            # if get_schema_parser_factory().reference_object().has_ref(data):
-            #     resp = self.process_response_from_reference(
-            #         init_response=init_response,
-            #         data=data,
-            #         get_schema_parser_factory=get_schema_parser_factory,
-            #     )
-            #     print(f"[DEBUG in _handle_object_type_value_with_object_strategy] resp: {resp}")
-            #     return resp["data"]
-            # elif "additionalProperties" in data.keys():
-
             # Check reference first
-            if has_ref:
+            if get_schema_parser_factory().reference_object().has_ref(data):
                 # Process reference
                 resp = self.process_response_from_reference(
                     init_response=init_response,
@@ -369,95 +357,31 @@ class ResponseStrategy(Enum):
                 print(f"[DEBUG in _handle_object_type_value_with_object_strategy] resp: {resp}")
                 return resp["data"]
             else:
-                # Process schema *additionalProperties* but without reference
-                if "additionalProperties" in data.keys():
-                    # Handle the schema *additionalProperties*
-                    additional_properties = data["additionalProperties"]
-                    additional_properties_type = convert_js_type(additional_properties["type"])
-                    if locate(additional_properties_type) in [list, dict, "file"]:
-                        items_config_data = _handle_list_type_value_with_object_strategy(additional_properties)
-                        print(
-                            f"[DEBUG in _handle_object_type_value_with_object_strategy] items_config_data: {items_config_data}"
-                        )
-                        return {
-                            "name": "",
-                            "required": _Default_Required.general,
-                            "type": additional_properties_type,
-                            # TODO: Set the *format* property correctly
-                            "format": None,
-                            "items": [items_config_data],
-                        }
-                    else:
-                        return {
-                            "name": "",
-                            "required": _Default_Required.general,
-                            "type": additional_properties_type,
-                            # TODO: Set the *format* property correctly
-                            "format": None,
-                            "items": None,
-                        }
+                # Handle the schema *additionalProperties*
+                additional_properties = data["additionalProperties"]
+                additional_properties_type = convert_js_type(additional_properties["type"])
+                if locate(additional_properties_type) in [list, dict, "file"]:
+                    items_config_data = _handle_list_type_value_with_object_strategy(additional_properties)
+                    print(
+                        f"[DEBUG in _handle_object_type_value_with_object_strategy] items_config_data: {items_config_data}"
+                    )
+                    return {
+                        "name": "",
+                        "required": _Default_Required.general,
+                        "type": additional_properties_type,
+                        # TODO: Set the *format* property correctly
+                        "format": None,
+                        "items": [items_config_data],
+                    }
                 else:
-                    # FIXME: it should focus on processing the config data which data structure is for one specific
-                    #  column, not for entire object.
-                    # Process non-reference
-                    resp = self.process_response_from_reference(
-                        init_response={"strategy": ResponseStrategy.OBJECT, "data": []},
-                        data=data,
-                        get_schema_parser_factory=get_schema_parser_factory,
-                    )
-                    print(
-                        f'[DEBUG in _handle_object_type_value_with_object_strategy] before *"additionalProperties" in data.keys()* data: {data}'
-                    )
-                    print(
-                        f"[DEBUG in _handle_object_type_value_with_object_strategy] don't have reference schema, it's the self data content"
-                    )
-                    print(f"[DEBUG in _handle_object_type_value_with_object_strategy] resp: {resp}")
-                    assert False
-                    # return {
-                    #     "name": "",
-                    #     "required": _Default_Required.general,
-                    #     "type": "dict",
-                    #     # TODO: Set the *format* property correctly
-                    #     "format": None,
-                    #     "items": resp["data"],
-                    # }
-
-                # if not get_schema_parser_factory().reference_object().has_ref(data):
-                #     resp = self.process_response_from_reference(
-                #         init_response={"strategy": ResponseStrategy.OBJECT, "data": []},
-                #         data=data,
-                #         get_schema_parser_factory=get_schema_parser_factory,
-                #         parse_from_schema=False,
-                #     )
-                #     print(f"[DEBUG in _handle_object_type_value_with_object_strategy] don't have reference schema, it's the self data content")
-                #     print(f"[DEBUG in _handle_object_type_value_with_object_strategy] resp: {resp}")
-                #     return {
-                #         "name": "",
-                #         "required": _Default_Required.general,
-                #         "type": "dict",
-                #         # TODO: Set the *format* property correctly
-                #         "format": None,
-                #         "items": resp["data"],
-                #     }
-                # resp = self.process_response_from_reference(
-                #     init_response=init_response,
-                #     data=data,
-                #     get_schema_parser_factory=get_schema_parser_factory,
-                # )
-                # print(f"[DEBUG in _handle_object_type_value_with_object_strategy] has reference schema")
-                # print(f"[DEBUG in _handle_object_type_value_with_object_strategy] resp: {resp}")
-                # return resp["data"]
-                # return {
-                #     "name": "",
-                #     "required": _Default_Required.general,
-                #     "type": "FIXME",
-                #     # TODO: Set the *format* property correctly
-                #     "format": None,
-                #     "items": None,
-                # }
-                # raise NotImplementedError(
-                #     "It should re-consider the parsing logic about handle object type config with object strategy."
-                # )
+                    return {
+                        "name": "",
+                        "required": _Default_Required.general,
+                        "type": additional_properties_type,
+                        # TODO: Set the *format* property correctly
+                        "format": None,
+                        "items": None,
+                    }
 
         def _handle_other_types_value_with_object_strategy(v_type: str) -> dict:
             return {

--- a/pymock_api/model/enums.py
+++ b/pymock_api/model/enums.py
@@ -353,7 +353,7 @@ class ResponseStrategy(Enum):
                     data=data,
                     get_schema_parser_factory=get_schema_parser_factory,
                 )
-                print(f"[DEBUG in _handle_object_type_value_with_object_strategy] has reference schema")
+                print("[DEBUG in _handle_object_type_value_with_object_strategy] has reference schema")
                 print(f"[DEBUG in _handle_object_type_value_with_object_strategy] resp: {resp}")
                 return resp["data"]
             else:

--- a/pymock_api/model/enums.py
+++ b/pymock_api/model/enums.py
@@ -109,35 +109,8 @@ class ResponseStrategy(Enum):
                     self._ensure_data_structure_when_non_object_strategy(init_response)
                     init_response["data"][k] = response_config
             print(f"[DEBUG in process_response_from_reference] parse with body, init_response: {init_response}")
-            return init_response
         else:
             # The section which doesn't have setting body
-            # response_config = self._generate_response(
-            #     init_response=init_response,
-            #     property_value={},  # It's {}
-            #     get_schema_parser_factory=get_schema_parser_factory,
-            # )
-            # print(
-            #     f"[DEBUG in process_response_from_reference] parse with empty body, response_config: {response_config}"
-            # )
-            # if self is ResponseStrategy.OBJECT:
-            #     response_data_prop = self._ensure_data_structure_when_object_strategy(init_response, response_config)
-            #     response_data_prop["name"] = response_schema_ref["title"]
-            #     response_data_prop["required"] = _Default_Required.empty
-            #     response_data_prop["type"] = "file"
-            #     init_response["data"].append(response_data_prop)
-            # else:
-            #     self._ensure_data_structure_when_non_object_strategy(init_response)
-            #     init_response["data"][response_schema_ref["title"]] = response_config
-
-            # TODO: Study here how to implement
-            # response_config = self._generate_response(
-            #     init_response={},
-            #     property_value={},  # It's {}
-            #     get_schema_parser_factory=get_schema_parser_factory,
-            #     property_key=empty_body_key,
-            # )
-
             response_config = self._generate_empty_response()  # type: ignore[assignment]
             if "title" in response_schema_ref.keys() and response_schema_ref["title"] == "InputStream":
                 if self is ResponseStrategy.OBJECT:
@@ -154,26 +127,9 @@ class ResponseStrategy(Enum):
             else:
                 self._ensure_data_structure_when_non_object_strategy(init_response)
                 init_response["data"][empty_body_key] = response_config
-
-            # empty_response = self._generate_empty_response()
-            # if self is ResponseStrategy.OBJECT:
-            #     response_data_prop = self._ensure_data_structure_when_object_strategy(
-            #         init_response, empty_response
-            #     )
-            #     print(f"[DEBUG in process_response_from_reference] response_data_prop: {response_data_prop}")
-            #     response_data_prop["name"] = empty_body_key
-            #     response_data_prop["required"] = empty_body_key in parser.get_required(default=[empty_body_key])
-            #     init_response["data"].append(response_data_prop)
-            # else:
-            #     self._ensure_data_structure_when_non_object_strategy(init_response)
-            #     init_response["data"][empty_body_key] = empty_response
-            # print(f"[DEBUG in process_response_from_reference] empty_response: {empty_response}")
-
             print(f"[DEBUG in process_response_from_reference] empty_body_key: {empty_body_key}")
             print(f"[DEBUG in process_response_from_reference] parse with empty body, init_response: {init_response}")
-            return init_response
-            # assert False
-        # return init_response
+        return init_response
 
     def process_response_from_data(
         self,

--- a/pymock_api/model/enums.py
+++ b/pymock_api/model/enums.py
@@ -53,11 +53,9 @@ class ResponseStrategy(Enum):
         data: dict,
         get_schema_parser_factory: Callable,
     ) -> dict:
-        response_schema_ref = get_schema_parser_factory().reference_object().get_schema_ref(data)
-        print(f"[DEBUG in process_response_from_reference] data: {data}")
         return self._process_reference_object(
             init_response=init_response,
-            response_schema_ref=response_schema_ref,
+            response_schema_ref=get_schema_parser_factory().reference_object().get_schema_ref(data),
             get_schema_parser_factory=get_schema_parser_factory,
         )
 

--- a/pymock_api/model/openapi/_schema_parser.py
+++ b/pymock_api/model/openapi/_schema_parser.py
@@ -244,10 +244,17 @@ class _ReferenceObjectParser:
         return data.get("schema", None) is not None
 
     @classmethod
+    def has_additional_properties(cls, data: Dict) -> bool:
+        return data.get("additionalProperties", None) is not None
+
+    @classmethod
     def has_ref(cls, data: Dict) -> str:
         if cls.has_schema(data):
             has_schema_ref = data["schema"].get("$ref", None) is not None
             return "schema" if has_schema_ref else ""
+        elif cls.has_additional_properties(data):
+            has_additional_properties = data["additionalProperties"].get("$ref", None) is not None
+            return "additionalProperties" if has_additional_properties else ""
         else:
             _has_ref = data.get("$ref", None) is not None
             return "ref" if _has_ref else ""
@@ -264,9 +271,7 @@ class _ReferenceObjectParser:
         _has_ref = _ReferenceObjectParser.has_ref(data)
         if not _has_ref:
             raise ValueError("This parameter has no ref in schema.")
-        schema_path = (
-            (data["schema"]["$ref"] if _has_ref == "schema" else data["$ref"]).replace("#/", "").split("/")[1:]
-        )
+        schema_path = (data[_has_ref]["$ref"] if _has_ref != "ref" else data["$ref"]).replace("#/", "").split("/")[1:]
         print(f"[DEBUG in get_schema_ref] schema_path: {schema_path}")
         # Operate the component definition object
         return _get_schema(get_component_definition(), schema_path, 0)

--- a/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_apply_test/_expected_api.yaml
+++ b/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_apply_test/_expected_api.yaml
@@ -1,0 +1,126 @@
+name: ''
+description: ''
+mocked_apis:
+  base:
+    url: '/api/v1/test'
+  apis:
+    get_foo:
+      url: '/foo'
+      http:
+        request:
+          method: 'GET'
+          parameters:
+            - name: 'date'
+              required: true
+              type: str
+            - name: 'fooType'
+              required: true
+              type: str
+        response:
+          strategy: object
+          properties:
+            - name: errorMessage
+              required: True
+              type: str
+            - name: responseCode
+              required: True
+              type: str
+            - name: responseData
+              required: False
+              type: list
+              items:
+                - name: id
+                  required: True
+                  type: int
+                - name: name
+                  required: True
+                  type: str
+                - name: value1
+                  required: True
+                  type: str
+                - name: value2
+                  required: True
+                  type: dict
+                  items:
+                    - name: personalInfo
+                      required: True
+                      type: dict
+                      items:
+                        - name: domain
+                          required: True
+                          type: str
+                        - name: url
+                          required: True
+                          type: str
+                    - name: jobExperience
+                      required: False
+                      type: dict
+                      items:
+                        - name: domain
+                          required: True
+                          type: str
+                        - name: url
+                          required: True
+                          type: str
+                    - name: sideProject
+                      required: False
+                      type: dict
+                      items:
+                        - name: domain
+                          required: True
+                          type: str
+                        - name: url
+                          required: True
+                          type: str
+      tag: 'foo'
+    get_foo-boo_export:
+      url: '/foo-boo/export'
+      http:
+        request:
+          method: 'GET'
+          parameters:
+            - name: 'arg1'
+              required: false
+              default: []
+              type: list
+              items:
+                - required: true
+                  type: str
+            - name: 'arg2'
+              required: false
+              default: ''
+              type: str
+            - name: 'datetime'
+              required: false
+              default: ''
+              type: str
+        response:
+          strategy: object
+          properties:
+            - name: description
+              required: True
+              type: str
+            # TODO: implement file stream
+            - name: file
+              required: True
+              type: file
+            - name: filename
+              required: True
+              type: str
+            # TODO: implement file stream
+            - name: inputStream
+              required: True
+              type: file
+            - name: open
+              required: True
+              type: bool
+            - name: readable
+              required: True
+              type: bool
+            - name: uri
+              required: True
+              type: str
+            - name: url
+              required: True
+              type: str
+      tag: 'foo-boo'

--- a/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_apply_test/_swagger-doc.json
+++ b/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_apply_test/_swagger-doc.json
@@ -1,0 +1,400 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "description": "Some description about this API documentation",
+        "version": "A1",
+        "title": "PyTest testing API",
+        "license": {}
+    },
+    "host": "127.0.0.1:8088",
+    "basePath": "/",
+    "tags": [
+        {
+            "name": "foo",
+            "description": "Foo Controller"
+        },
+        {
+            "name": "foo-boo",
+            "description": "Foo Boo Controller"
+        }
+    ],
+    "paths": {
+        "/api/v1/test/foo": {
+            "get": {
+                "tags": [
+                    "foo"
+                ],
+                "summary": "This is Foo API",
+                "description": "  400 - Bad request error\n 401 - Unauthorized error\n 404 - Not found voucher\n 500 - Unexpected error\n",
+                "operationId": "",
+                "produces": [
+                    "*/*"
+                ],
+                "parameters": [
+                    {
+                        "name": "date",
+                        "in": "query",
+                        "description": "Start date, format: ISO_OFFSET_DATE_TIME. Any special characters must be URL encoded, especially for `+`, `-`",
+                        "required": true,
+                        "type": "string",
+                        "format": "date-time",
+                        "x-example": "2022-03-06T00:00:00.000+09:00"
+                    },
+                    {
+                        "name": "fooType",
+                        "in": "query",
+                        "description": "Foo Type. Default value is selecting all.",
+                        "required": true,
+                        "type": "string",
+                        "x-example": "ENUM1",
+                        "enum": [
+                            "ENUM1",
+                            "ENUM2"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ResponseDTO«List«FooResponse»»"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "foo"
+                ],
+                "summary": "update Foo",
+                "description": "  400 - Bad request error\n 401 - Unauthorized error\n 404 - Not found voucher\n 500 - Unexpected error\n",
+                "operationId": "",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "*/*"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "request",
+                        "description": "request",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/UpdateFooRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ResponseDTO«Unit»"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/test/foo-boo/export": {
+            "get": {
+                "tags": [
+                    "foo-boo"
+                ],
+                "summary": "export something as file",
+                "operationId": "",
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "parameters": [
+                    {
+                        "name": "arg1",
+                        "in": "query",
+                        "required": false,
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "ENUM1",
+                                "ENUM2"
+                            ]
+                        },
+                        "collectionFormat": "multi",
+                        "enum": [
+                            "ENUM1",
+                            "ENUM2"
+                        ]
+                    },
+                    {
+                        "name": "arg2",
+                        "in": "query",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "ENUM1",
+                            "ENUM2"
+                        ]
+                    },
+                    {
+                        "name": "datetime",
+                        "in": "query",
+                        "required": false,
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Resource"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "TestResponse": {
+            "type": "object",
+            "required": [
+                "name",
+                "value"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            },
+            "title": "Test"
+        },
+        "Resource": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "file": {
+                    "type": "file"
+                },
+                "filename": {
+                    "type": "string"
+                },
+                "inputStream": {
+                    "$ref": "#/definitions/InputStream"
+                },
+                "open": {
+                    "type": "boolean"
+                },
+                "readable": {
+                    "type": "boolean"
+                },
+                "uri": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "url"
+                }
+            },
+            "title": "Resource"
+        },
+        "InputStream": {
+            "type": "object",
+            "title": "InputStream"
+        },
+        "ResponseDTO«List«FooResponse»»": {
+            "type": "object",
+            "required": [
+                "errorMessage",
+                "responseCode"
+            ],
+            "properties": {
+                "errorMessage": {
+                    "type": "string"
+                },
+                "responseCode": {
+                    "type": "string"
+                },
+                "responseData": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FooResponse"
+                    }
+                }
+            },
+            "title": "ResponseDTO«List«FooResponse»»"
+        },
+        "ResponseDTO«Unit»": {
+            "type": "object",
+            "required": [
+                "errorMessage",
+                "responseCode"
+            ],
+            "properties": {
+                "errorMessage": {
+                    "type": "string"
+                },
+                "responseCode": {
+                    "type": "string"
+                },
+                "responseData": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Unit"
+                    }
+                }
+            },
+            "title": "ResponseDTO«List«FooResponse»»"
+        },
+        "Sort": {
+            "type": "object",
+            "properties": {
+                "empty": {
+                    "type": "boolean"
+                },
+                "sorted": {
+                    "type": "boolean"
+                },
+                "unsorted": {
+                    "type": "boolean"
+                }
+            },
+            "title": "Sort"
+        },
+        "SwaggerPageable": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer",
+                    "format": "int32",
+                    "example": 0,
+                    "description": "Results page you want to retrieve (0..N)"
+                },
+                "size": {
+                    "type": "integer",
+                    "format": "int32",
+                    "example": 20,
+                    "description": "Number of records per page"
+                },
+                "sort": {
+                    "type": "string",
+                    "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported."
+                }
+            },
+            "title": "SwaggerPageable"
+        },
+        "UpdateFooRequest": {
+            "type": "object",
+            "required": [
+                "balances"
+            ],
+            "properties": {
+                "balances": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/UpdateOneFooDto"
+                    }
+                }
+            },
+            "title": "UpdateFooRequest"
+        },
+        "UpdateOneFooDto": {
+            "type": "object",
+            "required": [
+                "value",
+                "id"
+            ],
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "example": 23434,
+                    "description": "value"
+                },
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 1,
+                    "description": "ID"
+                }
+            },
+            "title": "UpdateOneFooDto"
+        },
+        "Unit": {
+            "type": "object",
+            "title": "Unit"
+        },
+        "FooResponse": {
+            "type": "object",
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "value1": {
+                    "type": "string"
+                },
+                "value2": {
+                    "type": "string",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/UrlProperties"
+                    }
+                }
+            },
+            "title": "FooResponse"
+        },
+        "UrlProperties": {
+            "type": "object",
+            "required": [
+                "personalInfo"
+            ],
+            "properties": {
+                "personalInfo": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/UrlDetail"
+                    }
+                },
+                "jobExperience": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/UrlDetail"
+                    }
+                },
+                "sideProject": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/UrlDetail"
+                    }
+                }
+            },
+            "title": "UrlProperties"
+        },
+        "UrlDetail": {
+            "type": "object",
+            "required": [
+                "domain",
+                "url"
+            ],
+            "properties": {
+                "domain": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
+            "title": "UrlProperties"
+        }
+    }
+}

--- a/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_apply_test/api.yaml
+++ b/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_apply_test/api.yaml
@@ -1,0 +1,28 @@
+# Swagger API documentation config from Kotlin Spring library
+name: ''
+description: ''
+mocked_apis:
+  template:    # Optional
+    activate: true
+    load_config:
+      includes_apis: True
+      order:
+        - 'apply'    # Load the setting by scanning files which naming be ruled by section *mocked_apis.template.apply*
+    values:
+      base_file_path: './test/data/divide_test_load/has-base-info_and_tags_and_nested_data_apply_test/'    # Default value should be current path './'
+      api:
+        config_path_format: '**-api.yaml'    # ex. ./foo/get_foo.yaml
+      http:
+        config_path_format: '**-http.yaml'
+      request:
+        config_path_format: '**-request.yaml'
+      response:
+        config_path_format: '**-response.yaml'
+    apply:    # Which mocked APIs should apply template values
+      api:    # Which mocked APIs should apply template values to its entire settings includes URL, request and response
+        - foo:    # If it has tag, it could set the tag name as key and set the target APIs as list type value of the key
+          - get_foo
+        - foo-boo:
+          - get_foo-boo_export
+  base:
+    url: '/api/v1/test'

--- a/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_apply_test/foo-boo/get_foo-boo_export-api.yaml
+++ b/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_apply_test/foo-boo/get_foo-boo_export-api.yaml
@@ -1,0 +1,49 @@
+url: '/foo-boo/export'
+http:
+  request:
+    method: 'GET'
+    parameters:
+      - name: 'arg1'
+        required: false
+        default: []
+        type: list
+        items:
+          - required: true
+            type: str
+      - name: 'arg2'
+        required: false
+        default: ''
+        type: str
+      - name: 'datetime'
+        required: false
+        default: ''
+        type: str
+  response:
+    strategy: object
+    properties:
+      - name: description
+        required: True
+        type: str
+      # TODO: implement file stream
+      - name: file
+        required: True
+        type: file
+      - name: filename
+        required: True
+        type: str
+      # TODO: implement file stream
+      - name: inputStream
+        required: True
+        type: file
+      - name: open
+        required: True
+        type: bool
+      - name: readable
+        required: True
+        type: bool
+      - name: uri
+        required: True
+        type: str
+      - name: url
+        required: True
+        type: str

--- a/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_apply_test/foo/get_foo-api.yaml
+++ b/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_apply_test/foo/get_foo-api.yaml
@@ -1,0 +1,67 @@
+url: '/foo'
+http:
+  request:
+    method: 'GET'
+    parameters:
+      - name: 'date'
+        required: true
+        type: str
+      - name: 'fooType'
+        required: true
+        type: str
+  response:
+    strategy: object
+    properties:
+      - name: errorMessage
+        required: True
+        type: str
+      - name: responseCode
+        required: True
+        type: str
+      - name: responseData
+        required: False
+        type: list
+        items:
+          - name: id
+            required: True
+            type: int
+          - name: name
+            required: True
+            type: str
+          - name: value1
+            required: True
+            type: str
+          - name: value2
+            required: True
+            type: dict
+            items:
+              - name: personalInfo
+                required: True
+                type: dict
+                items:
+                  - name: domain
+                    required: True
+                    type: str
+                  - name: url
+                    required: True
+                    type: str
+              - name: jobExperience
+                required: False
+                type: dict
+                items:
+                  - name: domain
+                    required: True
+                    type: str
+                  - name: url
+                    required: True
+                    type: str
+              - name: sideProject
+                required: False
+                type: dict
+                items:
+                  - name: domain
+                    required: True
+                    type: str
+                  - name: url
+                    required: True
+                    type: str

--- a/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_apply_test/foo/put_foo-api.yaml
+++ b/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_apply_test/foo/put_foo-api.yaml
@@ -1,0 +1,27 @@
+url: '/foo'
+http:
+  request:
+    method: 'PUT'
+    parameters:
+      - name: 'balances'
+        required: true
+        type: list
+        items:
+          - required: true
+            type: int
+            name: "value"
+          - required: true
+            type: int
+            name: "id"
+  response:
+    strategy: object
+    properties:
+      - name: errorMessage
+        required: True
+        type: str
+      - name: responseCode
+        required: True
+        type: str
+      - name: responseData
+        required: False
+        type: list

--- a/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/_expected_api.yaml
+++ b/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/_expected_api.yaml
@@ -1,0 +1,123 @@
+name: ''
+description: ''
+mocked_apis:
+  base:
+    url: '/api/v1/test'
+  apis:
+    get_foo:
+      url: '/foo'
+      http:
+        request:
+          apply_template_props: True
+          method: 'GET'
+          parameters:
+            - name: 'date'
+              required: true
+              type: str
+            - name: 'fooType'
+              required: true
+              type: str
+        response:
+          strategy: object
+          properties:
+            - name: errorMessage
+              required: True
+              type: str
+            - name: responseCode
+              required: True
+              type: str
+            - name: responseData
+              required: False
+              type: list
+              items:
+                - name: id
+                  required: True
+                  type: int
+                - name: name
+                  required: True
+                  type: str
+                - name: value1
+                  required: True
+                  type: str
+                - name: value2
+                  required: True
+                  type: str
+      tag: 'foo'
+    special_put_foo:
+      url: '/foo'
+      http:
+        request:
+          method: 'PUT'
+          parameters:
+            - name: 'balances'
+              required: true
+              type: list
+              items:
+                - required: true
+                  type: int
+                  name: "value"
+                - required: true
+                  type: int
+                  name: "id"
+        response:
+          strategy: object
+          properties:
+            - name: errorMessage
+              required: True
+              type: str
+            - name: responseCode
+              required: True
+              type: str
+            - name: responseData
+              required: False
+              type: list
+      tag: 'foo'
+    get_foo-boo_export:
+      url: '/foo-boo/export'
+      http:
+        request:
+          method: 'GET'
+          parameters:
+            - name: 'arg1'
+              required: false
+              type: list
+              items:
+                - required: true
+                  type: str
+            - name: 'arg2'
+              required: false
+              type: str
+            - name: 'datetime'
+              required: false
+              type: str
+        response:
+          apply_template_props: True
+          strategy: object
+          properties:
+            - name: description
+              required: True
+              type: str
+            # TODO: implement file stream
+            - name: file
+              required: True
+              type: file
+            - name: filename
+              required: True
+              type: str
+            # TODO: implement file stream
+            - name: inputStream
+              required: True
+              type: file
+            - name: open
+              required: True
+              type: bool
+            - name: readable
+              required: True
+              type: bool
+            - name: uri
+              required: True
+              type: str
+            - name: url
+              required: True
+              type: str
+      tag: 'foo-boo'

--- a/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/_swagger-doc.json
+++ b/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/_swagger-doc.json
@@ -1,0 +1,354 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "description": "Some description about this API documentation",
+        "version": "A1",
+        "title": "PyTest testing API",
+        "license": {}
+    },
+    "host": "127.0.0.1:8088",
+    "basePath": "/",
+    "tags": [
+        {
+            "name": "foo",
+            "description": "Foo Controller"
+        },
+        {
+            "name": "foo-boo",
+            "description": "Foo Boo Controller"
+        }
+    ],
+    "paths": {
+        "/api/v1/test/foo": {
+            "get": {
+                "tags": [
+                    "foo"
+                ],
+                "summary": "This is Foo API",
+                "description": "  400 - Bad request error\n 401 - Unauthorized error\n 404 - Not found voucher\n 500 - Unexpected error\n",
+                "operationId": "",
+                "produces": [
+                    "*/*"
+                ],
+                "parameters": [
+                    {
+                        "name": "date",
+                        "in": "query",
+                        "description": "Start date, format: ISO_OFFSET_DATE_TIME. Any special characters must be URL encoded, especially for `+`, `-`",
+                        "required": true,
+                        "type": "string",
+                        "format": "date-time",
+                        "x-example": "2022-03-06T00:00:00.000+09:00"
+                    },
+                    {
+                        "name": "fooType",
+                        "in": "query",
+                        "description": "Foo Type. Default value is selecting all.",
+                        "required": true,
+                        "type": "string",
+                        "x-example": "ENUM1",
+                        "enum": [
+                            "ENUM1",
+                            "ENUM2"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ResponseDTO«List«FooResponse»»"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "foo"
+                ],
+                "summary": "update Foo",
+                "description": "  400 - Bad request error\n 401 - Unauthorized error\n 404 - Not found voucher\n 500 - Unexpected error\n",
+                "operationId": "",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "*/*"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "request",
+                        "description": "request",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/UpdateFooRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ResponseDTO«Unit»"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/test/foo-boo/export": {
+            "get": {
+                "tags": [
+                    "foo-boo"
+                ],
+                "summary": "export something as file",
+                "operationId": "",
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "parameters": [
+                    {
+                        "name": "arg1",
+                        "in": "query",
+                        "required": false,
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "ENUM1",
+                                "ENUM2"
+                            ]
+                        },
+                        "collectionFormat": "multi",
+                        "enum": [
+                            "ENUM1",
+                            "ENUM2"
+                        ]
+                    },
+                    {
+                        "name": "arg2",
+                        "in": "query",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "ENUM1",
+                            "ENUM2"
+                        ]
+                    },
+                    {
+                        "name": "datetime",
+                        "in": "query",
+                        "required": false,
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Resource"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "TestResponse": {
+            "type": "object",
+            "required": [
+                "name",
+                "value"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            },
+            "title": "Test"
+        },
+        "Resource": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "file": {
+                    "type": "file"
+                },
+                "filename": {
+                    "type": "string"
+                },
+                "inputStream": {
+                    "$ref": "#/definitions/InputStream"
+                },
+                "open": {
+                    "type": "boolean"
+                },
+                "readable": {
+                    "type": "boolean"
+                },
+                "uri": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "url"
+                }
+            },
+            "title": "Resource"
+        },
+        "InputStream": {
+            "type": "object",
+            "title": "InputStream"
+        },
+        "ResponseDTO«List«FooResponse»»": {
+            "type": "object",
+            "required": [
+                "errorMessage",
+                "responseCode"
+            ],
+            "properties": {
+                "errorMessage": {
+                    "type": "string"
+                },
+                "responseCode": {
+                    "type": "string"
+                },
+                "responseData": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FooResponse"
+                    }
+                }
+            },
+            "title": "ResponseDTO«List«FooResponse»»"
+        },
+        "ResponseDTO«Unit»": {
+            "type": "object",
+            "required": [
+                "errorMessage",
+                "responseCode"
+            ],
+            "properties": {
+                "errorMessage": {
+                    "type": "string"
+                },
+                "responseCode": {
+                    "type": "string"
+                },
+                "responseData": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Unit"
+                    }
+                }
+            },
+            "title": "ResponseDTO«List«FooResponse»»"
+        },
+        "Sort": {
+            "type": "object",
+            "properties": {
+                "empty": {
+                    "type": "boolean"
+                },
+                "sorted": {
+                    "type": "boolean"
+                },
+                "unsorted": {
+                    "type": "boolean"
+                }
+            },
+            "title": "Sort"
+        },
+        "SwaggerPageable": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer",
+                    "format": "int32",
+                    "example": 0,
+                    "description": "Results page you want to retrieve (0..N)"
+                },
+                "size": {
+                    "type": "integer",
+                    "format": "int32",
+                    "example": 20,
+                    "description": "Number of records per page"
+                },
+                "sort": {
+                    "type": "string",
+                    "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported."
+                }
+            },
+            "title": "SwaggerPageable"
+        },
+        "UpdateFooRequest": {
+            "type": "object",
+            "required": [
+                "balances"
+            ],
+            "properties": {
+                "balances": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/UpdateOneFooDto"
+                    }
+                }
+            },
+            "title": "UpdateFooRequest"
+        },
+        "UpdateOneFooDto": {
+            "type": "object",
+            "required": [
+                "value",
+                "id"
+            ],
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "example": 23434,
+                    "description": "value"
+                },
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 1,
+                    "description": "ID"
+                }
+            },
+            "title": "UpdateOneFooDto"
+        },
+        "Unit": {
+            "type": "object",
+            "title": "Unit"
+        },
+        "FooResponse": {
+            "type": "object",
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "value1": {
+                    "type": "string"
+                },
+                "value2": {
+                    "type": "string"
+                }
+            },
+            "title": "FooResponse"
+        }
+    }
+}

--- a/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/api.yaml
+++ b/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/api.yaml
@@ -1,0 +1,35 @@
+# Swagger API documentation config from Kotlin Spring library
+name: ''
+description: ''
+mocked_apis:
+  template:    # Optional
+    activate: true
+    load_config:
+      includes_apis: True
+      order:
+        - 'apis'
+        - 'apply'
+        - 'file'
+    values:
+      base_file_path: './test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/'    # Default value should be current path './'
+      api:
+        config_path_format: '**-api.yaml'    # ex. ./foo/get_foo.yaml
+      http:
+        config_path_format: '**-http.yaml'
+      request:
+        config_path_format: '**-request.yaml'
+      response:
+        config_path_format: '**-response.yaml'
+    apply:    # Which mocked APIs should apply template values
+      api:    # Which mocked APIs should apply template values to its entire settings includes URL, request and response
+        - foo:    # If it has tag, it could set the tag name as key and set the target APIs as list type value of the key
+          - get_foo
+        - foo-boo:
+          - get_foo-boo_export
+  base:
+    url: '/api/v1/test'
+  apis:
+    special_put_foo:
+      apply_template_props: True
+      base_file_path: './test/data/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/special_put_foo'
+#      base_file_path: '{{template.api.base_file_path}}/foo'

--- a/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/foo-boo/get_foo-boo_export-api.yaml
+++ b/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/foo-boo/get_foo-boo_export-api.yaml
@@ -1,0 +1,28 @@
+url: '/foo-boo/export'
+http:
+  request:
+    method: 'GET'
+    parameters:
+      - name: 'arg1'
+        required: false
+        default:
+        type: list
+        format:
+        items:
+          - required: true
+            type: str
+      - name: 'arg2'
+        required: false
+        default:
+        type: str
+        format:
+      - name: 'datetime'
+        required: false
+        default:
+        type: str
+        format:
+  response:
+    apply_template_props: True
+    base_file_path: './test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/foo-boo'
+    config_path:
+    config_path_format: '**-response'

--- a/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/foo-boo/get_foo-boo_export-response.yaml
+++ b/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/foo-boo/get_foo-boo_export-response.yaml
@@ -1,0 +1,36 @@
+strategy: object
+properties:
+  - name: description
+    required: True
+    type: str
+    format:
+  # TODO: implement file stream
+  - name: file
+    required: True
+    type: file
+    format:
+  - name: filename
+    required: True
+    type: str
+    format:
+  # TODO: implement file stream
+  - name: inputStream
+    required: True
+    type: file
+    format:
+  - name: open
+    required: True
+    type: bool
+    format:
+  - name: readable
+    required: True
+    type: bool
+    format:
+  - name: uri
+    required: True
+    type: str
+    format:
+  - name: url
+    required: True
+    type: str
+    format:

--- a/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/foo/get_foo-api.yaml
+++ b/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/foo/get_foo-api.yaml
@@ -1,0 +1,35 @@
+url: '/foo'
+http:
+  request:
+    apply_template_props: True
+    base_file_path: './test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/foo'
+    config_path:
+    config_path_format: '**-request'
+  response:
+    strategy: object
+    properties:
+      - name: errorMessage
+        required: True
+        type: str
+        format:
+      - name: responseCode
+        required: True
+        type: str
+        format:
+      - name: responseData
+        required: False
+        type: list
+        format:
+        items:
+          - name: id
+            required: True
+            type: int
+          - name: name
+            required: True
+            type: str
+          - name: value1
+            required: True
+            type: str
+          - name: value2
+            required: True
+            type: str

--- a/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/foo/get_foo-request.yaml
+++ b/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/foo/get_foo-request.yaml
@@ -1,0 +1,12 @@
+method: 'GET'
+parameters:
+  - name: 'date'
+    required: true
+    default:
+    type: str
+    format:
+  - name: 'fooType'
+    required: true
+    default:
+    type: str
+    format:

--- a/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/special_put_foo/special_put_foo-api.yaml
+++ b/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/special_put_foo/special_put_foo-api.yaml
@@ -1,0 +1,6 @@
+url: '/foo'
+http:
+  apply_template_props: True
+  base_file_path: './test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/special_put_foo'
+  config_path:
+  config_path_format: '**-http'

--- a/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/special_put_foo/special_put_foo-http.yaml
+++ b/test/data/divide_test_load/has-base-info_and_tags_and_nested_data_has_mocked_apis_with_divide_http_test/special_put_foo/special_put_foo-http.yaml
@@ -1,0 +1,25 @@
+request:
+  method: 'PUT'
+  parameters:
+    - name: 'balances'
+      required: true
+      type: list
+      items:
+        - required: true
+          type: int
+          name: "value"
+        - required: true
+          type: int
+          name: "id"
+response:
+  strategy: object
+  properties:
+    - name: errorMessage
+      required: True
+      type: str
+    - name: responseCode
+      required: True
+      type: str
+    - name: responseData
+      required: False
+      type: list

--- a/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/api.yaml
+++ b/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/api.yaml
@@ -1,0 +1,23 @@
+# Swagger API documentation config from Kotlin Spring library
+name: ''
+description: ''
+mocked_apis:
+  template:    # Optional
+    activate: true
+    load_config:
+      includes_apis: True
+      order:
+        - 'apis'    # Load the setting by scanning files which naming be ruled by section *mocked_apis.template.apply*
+        - 'file'    # Load the setting by scanning files which naming be ruled by section *mocked_apis.template.apply*
+    values:
+      base_file_path: './test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/'    # Default value should be current path './'
+      api:
+        config_path_format: '**-api.yaml'    # ex. ./foo/get_foo.yaml
+      http:
+        config_path_format: '**-http.yaml'
+      request:
+        config_path_format: '**-request.yaml'
+      response:
+        config_path_format: '**-response.yaml'
+  base:
+    url: '/api/v1/test'

--- a/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-api.yaml
+++ b/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-api.yaml
@@ -1,0 +1,2 @@
+url: '/foo-boo/export'
+tag: foo-boo

--- a/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-http.yaml
+++ b/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-http.yaml
@@ -1,0 +1,15 @@
+request:
+  method: 'GET'
+  parameters:
+    - name: 'arg1'
+      required: false
+      type: list
+      items:
+        - required: true
+          type: str
+    - name: 'arg2'
+      required: false
+      type: str
+    - name: 'datetime'
+      required: false
+      type: str

--- a/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-response.yaml
+++ b/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-response.yaml
@@ -1,0 +1,28 @@
+strategy: object
+properties:
+  - name: description
+    required: True
+    type: str
+  # TODO: implement file stream
+  - name: file
+    required: True
+    type: file
+  - name: filename
+    required: True
+    type: str
+  # TODO: implement file stream
+  - name: inputStream
+    required: True
+    type: file
+  - name: open
+    required: True
+    type: bool
+  - name: readable
+    required: True
+    type: bool
+  - name: uri
+    required: True
+    type: str
+  - name: url
+    required: True
+    type: str

--- a/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo/get_foo-api.yaml
+++ b/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo/get_foo-api.yaml
@@ -1,0 +1,3 @@
+url: '/foo'
+tag: foo
+http:

--- a/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo/get_foo-http.yaml
+++ b/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo/get_foo-http.yaml
@@ -1,0 +1,9 @@
+request:
+  method: 'GET'
+  parameters:
+    - name: 'date'
+      required: true
+      type: str
+    - name: 'fooType'
+      required: true
+      type: str

--- a/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo/get_foo-response.yaml
+++ b/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo/get_foo-response.yaml
@@ -19,6 +19,37 @@ properties:
       - name: value1
         required: True
         type: str
-#      - name: value2
-#        required: True
-#        type: str
+      - name: info
+        required: False
+        type: dict
+        items:
+          - name: personalInfo
+            required: True
+            type: dict
+            items:
+              - name: domain
+                required: True
+                type: str
+              - name: url
+                required: True
+                type: str
+          - name: jobExperience
+            required: False
+            type: dict
+            items:
+              - name: domain
+                required: True
+                type: str
+              - name: url
+                required: True
+                type: str
+          - name: sideProject
+            required: False
+            type: dict
+            items:
+              - name: domain
+                required: True
+                type: str
+              - name: url
+                required: True
+                type: str

--- a/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo/get_foo-response.yaml
+++ b/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo/get_foo-response.yaml
@@ -1,0 +1,24 @@
+strategy: object
+properties:
+  - name: errorMessage
+    required: True
+    type: str
+  - name: responseCode
+    required: True
+    type: str
+  - name: responseData
+    required: False
+    type: list
+    items:
+      - name: id
+        required: True
+        type: int
+      - name: name
+        required: True
+        type: str
+      - name: value1
+        required: True
+        type: str
+#      - name: value2
+#        required: True
+#        type: str

--- a/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo/put_foo-api.yaml
+++ b/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo/put_foo-api.yaml
@@ -1,0 +1,3 @@
+url: '/foo'
+tag: foo
+http:

--- a/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo/put_foo-http.yaml
+++ b/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo/put_foo-http.yaml
@@ -1,0 +1,13 @@
+request:
+  method: 'PUT'
+  parameters:
+    - name: 'balances'
+      required: true
+      type: list
+      items:
+        - required: true
+          type: int
+          name: "value"
+        - required: true
+          type: int
+          name: "id"

--- a/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo/put_foo-response.yaml
+++ b/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo/put_foo-response.yaml
@@ -1,0 +1,11 @@
+strategy: object
+properties:
+  - name: errorMessage
+    required: True
+    type: str
+  - name: responseCode
+    required: True
+    type: str
+  - name: responseData
+    required: False
+    type: list

--- a/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/swagger_api.json
+++ b/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/swagger_api.json
@@ -1,0 +1,400 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "description": "Some description about this API documentation",
+        "version": "A1",
+        "title": "PyTest testing API",
+        "license": {}
+    },
+    "host": "127.0.0.1:8088",
+    "basePath": "/",
+    "tags": [
+        {
+            "name": "foo",
+            "description": "Foo Controller"
+        },
+        {
+            "name": "foo-boo",
+            "description": "Foo Boo Controller"
+        }
+    ],
+    "paths": {
+        "/api/v1/test/foo": {
+            "get": {
+                "tags": [
+                    "foo"
+                ],
+                "summary": "This is Foo API",
+                "description": "  400 - Bad request error\n 401 - Unauthorized error\n 404 - Not found voucher\n 500 - Unexpected error\n",
+                "operationId": "",
+                "produces": [
+                    "*/*"
+                ],
+                "parameters": [
+                    {
+                        "name": "date",
+                        "in": "query",
+                        "description": "Start date, format: ISO_OFFSET_DATE_TIME. Any special characters must be URL encoded, especially for `+`, `-`",
+                        "required": true,
+                        "type": "string",
+                        "format": "date-time",
+                        "x-example": "2022-03-06T00:00:00.000+09:00"
+                    },
+                    {
+                        "name": "fooType",
+                        "in": "query",
+                        "description": "Foo Type. Default value is selecting all.",
+                        "required": true,
+                        "type": "string",
+                        "x-example": "ENUM1",
+                        "enum": [
+                            "ENUM1",
+                            "ENUM2"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ResponseDTO«List«FooResponse»»"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "foo"
+                ],
+                "summary": "update Foo",
+                "description": "  400 - Bad request error\n 401 - Unauthorized error\n 404 - Not found voucher\n 500 - Unexpected error\n",
+                "operationId": "",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "*/*"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "request",
+                        "description": "request",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/UpdateFooRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ResponseDTO«Unit»"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/test/foo-boo/export": {
+            "get": {
+                "tags": [
+                    "foo-boo"
+                ],
+                "summary": "export something as file",
+                "operationId": "",
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "parameters": [
+                    {
+                        "name": "arg1",
+                        "in": "query",
+                        "required": false,
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "ENUM1",
+                                "ENUM2"
+                            ]
+                        },
+                        "collectionFormat": "multi",
+                        "enum": [
+                            "ENUM1",
+                            "ENUM2"
+                        ]
+                    },
+                    {
+                        "name": "arg2",
+                        "in": "query",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "ENUM1",
+                            "ENUM2"
+                        ]
+                    },
+                    {
+                        "name": "datetime",
+                        "in": "query",
+                        "required": false,
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Resource"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "TestResponse": {
+            "type": "object",
+            "required": [
+                "name",
+                "value"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            },
+            "title": "Test"
+        },
+        "Resource": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "file": {
+                    "type": "file"
+                },
+                "filename": {
+                    "type": "string"
+                },
+                "inputStream": {
+                    "$ref": "#/definitions/InputStream"
+                },
+                "open": {
+                    "type": "boolean"
+                },
+                "readable": {
+                    "type": "boolean"
+                },
+                "uri": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "url"
+                }
+            },
+            "title": "Resource"
+        },
+        "InputStream": {
+            "type": "object",
+            "title": "InputStream"
+        },
+        "ResponseDTO«List«FooResponse»»": {
+            "type": "object",
+            "required": [
+                "errorMessage",
+                "responseCode"
+            ],
+            "properties": {
+                "errorMessage": {
+                    "type": "string"
+                },
+                "responseCode": {
+                    "type": "string"
+                },
+                "responseData": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FooResponse"
+                    }
+                }
+            },
+            "title": "ResponseDTO«List«FooResponse»»"
+        },
+        "ResponseDTO«Unit»": {
+            "type": "object",
+            "required": [
+                "errorMessage",
+                "responseCode"
+            ],
+            "properties": {
+                "errorMessage": {
+                    "type": "string"
+                },
+                "responseCode": {
+                    "type": "string"
+                },
+                "responseData": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Unit"
+                    }
+                }
+            },
+            "title": "ResponseDTO«List«FooResponse»»"
+        },
+        "Sort": {
+            "type": "object",
+            "properties": {
+                "empty": {
+                    "type": "boolean"
+                },
+                "sorted": {
+                    "type": "boolean"
+                },
+                "unsorted": {
+                    "type": "boolean"
+                }
+            },
+            "title": "Sort"
+        },
+        "SwaggerPageable": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer",
+                    "format": "int32",
+                    "example": 0,
+                    "description": "Results page you want to retrieve (0..N)"
+                },
+                "size": {
+                    "type": "integer",
+                    "format": "int32",
+                    "example": 20,
+                    "description": "Number of records per page"
+                },
+                "sort": {
+                    "type": "string",
+                    "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported."
+                }
+            },
+            "title": "SwaggerPageable"
+        },
+        "UpdateFooRequest": {
+            "type": "object",
+            "required": [
+                "balances"
+            ],
+            "properties": {
+                "balances": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/UpdateOneFooDto"
+                    }
+                }
+            },
+            "title": "UpdateFooRequest"
+        },
+        "UpdateOneFooDto": {
+            "type": "object",
+            "required": [
+                "value",
+                "id"
+            ],
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "example": 23434,
+                    "description": "value"
+                },
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 1,
+                    "description": "ID"
+                }
+            },
+            "title": "UpdateOneFooDto"
+        },
+        "Unit": {
+            "type": "object",
+            "title": "Unit"
+        },
+        "FooResponse": {
+            "type": "object",
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "value1": {
+                    "type": "string"
+                },
+                "info": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/UrlProperties"
+                    }
+                }
+            },
+            "title": "FooResponse"
+        },
+        "UrlProperties": {
+            "type": "object",
+            "required": [
+                "personalInfo"
+            ],
+            "properties": {
+                "personalInfo": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/UrlDetail"
+                    }
+                },
+                "jobExperience": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/UrlDetail"
+                    }
+                },
+                "sideProject": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/UrlDetail"
+                    }
+                }
+            },
+            "title": "UrlProperties"
+        },
+        "UrlDetail": {
+            "type": "object",
+            "required": [
+                "domain",
+                "url"
+            ],
+            "properties": {
+                "domain": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
+            "title": "UrlProperties"
+        }
+    }
+}

--- a/test/data/divide_test_pull/divide_api_with_nested_data+has_tag/expect_config/api.yaml
+++ b/test/data/divide_test_pull/divide_api_with_nested_data+has_tag/expect_config/api.yaml
@@ -1,0 +1,28 @@
+# Swagger API documentation config from Kotlin Spring library
+name: ''
+description: ''
+mocked_apis:
+  template:    # Optional
+    activate: true
+    load_config:
+      includes_apis: True
+      order:
+        - 'apply'    # Load the setting by scanning files which naming be ruled by section *mocked_apis.template.apply*
+    values:
+      base_file_path: './test/data/divide_test_pull/divide_api_with_nested_data+has_tag/expect_config'    # Default value should be current path './'
+      api:
+        config_path_format: '**-api.yaml'    # ex. ./foo/get_foo.yaml
+      http:
+        config_path_format: '**-http.yaml'
+      request:
+        config_path_format: '**-request.yaml'
+      response:
+        config_path_format: '**-response.yaml'
+    apply:    # Which mocked APIs should apply template values
+      api:    # Which mocked APIs should apply template values to its entire settings includes URL, request and response
+        - foo:    # If it has tag, it could set the tag name as key and set the target APIs as list type value of the key
+          - get_foo
+        - foo-boo:
+          - get_foo-boo_export
+  base:
+    url: '/api/v1/test'

--- a/test/data/divide_test_pull/divide_api_with_nested_data+has_tag/expect_config/foo-boo/get_foo-boo_export-api.yaml
+++ b/test/data/divide_test_pull/divide_api_with_nested_data+has_tag/expect_config/foo-boo/get_foo-boo_export-api.yaml
@@ -1,0 +1,47 @@
+url: '/foo-boo/export'
+tag: foo-boo
+http:
+  request:
+    method: 'GET'
+    parameters:
+      - name: 'arg1'
+        required: false
+        type: list
+        items:
+          - required: true
+            type: str
+      - name: 'arg2'
+        required: false
+        type: str
+      - name: 'datetime'
+        required: false
+        type: str
+  response:
+    strategy: object
+    properties:
+      - name: description
+        required: True
+        type: str
+      # TODO: implement file stream
+      - name: file
+        required: True
+        type: file
+      - name: filename
+        required: True
+        type: str
+      # TODO: implement file stream
+      - name: inputStream
+        required: True
+        type: file
+      - name: open
+        required: True
+        type: bool
+      - name: readable
+        required: True
+        type: bool
+      - name: uri
+        required: True
+        type: str
+      - name: url
+        required: True
+        type: str

--- a/test/data/divide_test_pull/divide_api_with_nested_data+has_tag/expect_config/foo/get_foo-api.yaml
+++ b/test/data/divide_test_pull/divide_api_with_nested_data+has_tag/expect_config/foo/get_foo-api.yaml
@@ -1,0 +1,68 @@
+url: '/foo'
+tag: foo
+http:
+  request:
+    method: 'GET'
+    parameters:
+      - name: 'date'
+        required: true
+        type: str
+      - name: 'fooType'
+        required: true
+        type: str
+  response:
+    strategy: object
+    properties:
+      - name: errorMessage
+        required: True
+        type: str
+      - name: responseCode
+        required: True
+        type: str
+      - name: responseData
+        required: False
+        type: list
+        items:
+          - name: id
+            required: True
+            type: int
+          - name: name
+            required: True
+            type: str
+          - name: value1
+            required: True
+            type: str
+          - name: info
+            required: False
+            type: dict
+            items:
+              - name: personalInfo
+                required: True
+                type: dict
+                items:
+                  - name: domain
+                    required: True
+                    type: str
+                  - name: url
+                    required: True
+                    type: str
+              - name: jobExperience
+                required: False
+                type: dict
+                items:
+                  - name: domain
+                    required: True
+                    type: str
+                  - name: url
+                    required: True
+                    type: str
+              - name: sideProject
+                required: False
+                type: dict
+                items:
+                  - name: domain
+                    required: True
+                    type: str
+                  - name: url
+                    required: True
+                    type: str

--- a/test/data/divide_test_pull/divide_api_with_nested_data+has_tag/expect_config/foo/put_foo-api.yaml
+++ b/test/data/divide_test_pull/divide_api_with_nested_data+has_tag/expect_config/foo/put_foo-api.yaml
@@ -1,0 +1,28 @@
+url: '/foo'
+tag: foo
+http:
+  request:
+    method: 'PUT'
+    parameters:
+      - name: 'balances'
+        required: true
+        type: list
+        items:
+          - required: true
+            type: int
+            name: "value"
+          - required: true
+            type: int
+            name: "id"
+  response:
+    strategy: object
+    properties:
+      - name: errorMessage
+        required: True
+        type: str
+      - name: responseCode
+        required: True
+        type: str
+      - name: responseData
+        required: False
+        type: list

--- a/test/data/divide_test_pull/divide_api_with_nested_data+has_tag/swagger_api.json
+++ b/test/data/divide_test_pull/divide_api_with_nested_data+has_tag/swagger_api.json
@@ -1,0 +1,400 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "description": "Some description about this API documentation",
+        "version": "A1",
+        "title": "PyTest testing API",
+        "license": {}
+    },
+    "host": "127.0.0.1:8088",
+    "basePath": "/",
+    "tags": [
+        {
+            "name": "foo",
+            "description": "Foo Controller"
+        },
+        {
+            "name": "foo-boo",
+            "description": "Foo Boo Controller"
+        }
+    ],
+    "paths": {
+        "/api/v1/test/foo": {
+            "get": {
+                "tags": [
+                    "foo"
+                ],
+                "summary": "This is Foo API",
+                "description": "  400 - Bad request error\n 401 - Unauthorized error\n 404 - Not found voucher\n 500 - Unexpected error\n",
+                "operationId": "",
+                "produces": [
+                    "*/*"
+                ],
+                "parameters": [
+                    {
+                        "name": "date",
+                        "in": "query",
+                        "description": "Start date, format: ISO_OFFSET_DATE_TIME. Any special characters must be URL encoded, especially for `+`, `-`",
+                        "required": true,
+                        "type": "string",
+                        "format": "date-time",
+                        "x-example": "2022-03-06T00:00:00.000+09:00"
+                    },
+                    {
+                        "name": "fooType",
+                        "in": "query",
+                        "description": "Foo Type. Default value is selecting all.",
+                        "required": true,
+                        "type": "string",
+                        "x-example": "ENUM1",
+                        "enum": [
+                            "ENUM1",
+                            "ENUM2"
+                        ]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ResponseDTO«List«FooResponse»»"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "foo"
+                ],
+                "summary": "update Foo",
+                "description": "  400 - Bad request error\n 401 - Unauthorized error\n 404 - Not found voucher\n 500 - Unexpected error\n",
+                "operationId": "",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "*/*"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "request",
+                        "description": "request",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/UpdateFooRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ResponseDTO«Unit»"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/test/foo-boo/export": {
+            "get": {
+                "tags": [
+                    "foo-boo"
+                ],
+                "summary": "export something as file",
+                "operationId": "",
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "parameters": [
+                    {
+                        "name": "arg1",
+                        "in": "query",
+                        "required": false,
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "ENUM1",
+                                "ENUM2"
+                            ]
+                        },
+                        "collectionFormat": "multi",
+                        "enum": [
+                            "ENUM1",
+                            "ENUM2"
+                        ]
+                    },
+                    {
+                        "name": "arg2",
+                        "in": "query",
+                        "required": false,
+                        "type": "string",
+                        "enum": [
+                            "ENUM1",
+                            "ENUM2"
+                        ]
+                    },
+                    {
+                        "name": "datetime",
+                        "in": "query",
+                        "required": false,
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Resource"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "TestResponse": {
+            "type": "object",
+            "required": [
+                "name",
+                "value"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            },
+            "title": "Test"
+        },
+        "Resource": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "file": {
+                    "type": "file"
+                },
+                "filename": {
+                    "type": "string"
+                },
+                "inputStream": {
+                    "$ref": "#/definitions/InputStream"
+                },
+                "open": {
+                    "type": "boolean"
+                },
+                "readable": {
+                    "type": "boolean"
+                },
+                "uri": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "url"
+                }
+            },
+            "title": "Resource"
+        },
+        "InputStream": {
+            "type": "object",
+            "title": "InputStream"
+        },
+        "ResponseDTO«List«FooResponse»»": {
+            "type": "object",
+            "required": [
+                "errorMessage",
+                "responseCode"
+            ],
+            "properties": {
+                "errorMessage": {
+                    "type": "string"
+                },
+                "responseCode": {
+                    "type": "string"
+                },
+                "responseData": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FooResponse"
+                    }
+                }
+            },
+            "title": "ResponseDTO«List«FooResponse»»"
+        },
+        "ResponseDTO«Unit»": {
+            "type": "object",
+            "required": [
+                "errorMessage",
+                "responseCode"
+            ],
+            "properties": {
+                "errorMessage": {
+                    "type": "string"
+                },
+                "responseCode": {
+                    "type": "string"
+                },
+                "responseData": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Unit"
+                    }
+                }
+            },
+            "title": "ResponseDTO«List«FooResponse»»"
+        },
+        "Sort": {
+            "type": "object",
+            "properties": {
+                "empty": {
+                    "type": "boolean"
+                },
+                "sorted": {
+                    "type": "boolean"
+                },
+                "unsorted": {
+                    "type": "boolean"
+                }
+            },
+            "title": "Sort"
+        },
+        "SwaggerPageable": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer",
+                    "format": "int32",
+                    "example": 0,
+                    "description": "Results page you want to retrieve (0..N)"
+                },
+                "size": {
+                    "type": "integer",
+                    "format": "int32",
+                    "example": 20,
+                    "description": "Number of records per page"
+                },
+                "sort": {
+                    "type": "string",
+                    "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported."
+                }
+            },
+            "title": "SwaggerPageable"
+        },
+        "UpdateFooRequest": {
+            "type": "object",
+            "required": [
+                "balances"
+            ],
+            "properties": {
+                "balances": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/UpdateOneFooDto"
+                    }
+                }
+            },
+            "title": "UpdateFooRequest"
+        },
+        "UpdateOneFooDto": {
+            "type": "object",
+            "required": [
+                "value",
+                "id"
+            ],
+            "properties": {
+                "value": {
+                    "type": "number",
+                    "example": 23434,
+                    "description": "value"
+                },
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 1,
+                    "description": "ID"
+                }
+            },
+            "title": "UpdateOneFooDto"
+        },
+        "Unit": {
+            "type": "object",
+            "title": "Unit"
+        },
+        "FooResponse": {
+            "type": "object",
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "value1": {
+                    "type": "string"
+                },
+                "info": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/UrlProperties"
+                    }
+                }
+            },
+            "title": "FooResponse"
+        },
+        "UrlProperties": {
+            "type": "object",
+            "required": [
+                "personalInfo"
+            ],
+            "properties": {
+                "personalInfo": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/UrlDetail"
+                    }
+                },
+                "jobExperience": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/UrlDetail"
+                    }
+                },
+                "sideProject": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/UrlDetail"
+                    }
+                }
+            },
+            "title": "UrlProperties"
+        },
+        "UrlDetail": {
+            "type": "object",
+            "required": [
+                "domain",
+                "url"
+            ],
+            "properties": {
+                "domain": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
+            "title": "UrlProperties"
+        }
+    }
+}

--- a/test/unit_test/model/api_config/apis/response.py
+++ b/test/unit_test/model/api_config/apis/response.py
@@ -13,6 +13,7 @@ from ....._values import (
     _Test_HTTP_Resp,
     _Test_Response_Property_Dict,
     _Test_Response_Property_List,
+    _Test_Response_Property_Priority_Dict,
     _TestConfig,
 )
 from .._base import (
@@ -112,6 +113,16 @@ class TestResponsePropertyWithNestedData(TestResponseProperty):
             assert list(filter(lambda i: i["name"] == item.name, _Test_Response_Property_Dict["items"]))
             assert list(filter(lambda i: i["required"] == item.required, _Test_Response_Property_Dict["items"]))
             assert list(filter(lambda i: i["type"] == item.value_type, _Test_Response_Property_Dict["items"]))
+
+    def test_compare_with_other_has_different_element(self, sut: ResponseProperty):
+        copy_sut = ResponseProperty(
+            name=sut.name,
+            required=sut.required,
+            value_type=sut.value_type,
+            value_format=sut.value_format,
+            items=_Test_Response_Property_Priority_Dict["items"],
+        )
+        assert sut != copy_sut
 
 
 class TestHTTPResponse(TemplatableConfigTestSuite, CheckableTestSuite):

--- a/test/unit_test/model/api_config/apis/response.py
+++ b/test/unit_test/model/api_config/apis/response.py
@@ -1,6 +1,6 @@
 import random
 import re
-from typing import Any, List
+from typing import Any, Type
 
 import pytest
 
@@ -18,6 +18,7 @@ from ....._values import (
 from .._base import (
     CheckableTestSuite,
     ConfigTestSpec,
+    HasItemsPropConfigTestSuite,
     MockModel,
     _assertion_msg,
     set_checking_test_data,
@@ -76,7 +77,7 @@ class TestResponseProperty(ConfigTestSpec):
         )
 
 
-class TestResponsePropertyWithNestedData(TestResponseProperty):
+class TestResponsePropertyWithNestedData(TestResponseProperty, HasItemsPropConfigTestSuite):
     @pytest.fixture(scope="function")
     def sut(self) -> ResponseProperty:
         return ResponseProperty(
@@ -113,96 +114,18 @@ class TestResponsePropertyWithNestedData(TestResponseProperty):
             assert list(filter(lambda i: i["required"] == item.required, _Test_Response_Property_Dict["items"]))
             assert list(filter(lambda i: i["type"] == item.value_type, _Test_Response_Property_Dict["items"]))
 
-    @pytest.mark.parametrize(
-        "items_data",
-        [
-            # Miss columns
-            [
-                {"name": "id", "required": True, "type": "str"},
-                {"name": "name", "required": True, "type": "str"},
-            ],
-            # Have columns it doesn't have
-            [
-                {"name": "id", "required": True, "type": "str"},
-                {"name": "name", "required": True, "type": "str"},
-                {"name": "what_is_this", "required": True, "type": "str"},
-            ],
-            # Details in property *items* are different
-            [
-                {"name": "id", "required": True, "type": "str"},
-                {"name": "name", "required": True, "type": "str"},
-                {"name": "project", "required": False, "type": "list", "items": [{"required": True, "type": "str"}]},
-                {
-                    "name": "responsibility",
-                    "required": True,
-                    "type": "list",
-                    "items": [
-                        {"name": "project", "required": True, "type": "str"},
-                        {
-                            "name": "language",
-                            "required": True,
-                            "type": "list",
-                            "items": [{"required": True, "type": "str"}],
-                        },
-                    ],
-                },
-            ],
-            # Details in property *items.items* are different
-            [
-                {"name": "id", "required": True, "type": "str"},
-                {"name": "name", "required": True, "type": "str"},
-                {"name": "project", "required": True, "type": "list", "items": [{"required": True, "type": "int"}]},
-                {
-                    "name": "responsibility",
-                    "required": True,
-                    "type": "list",
-                    "items": [
-                        {"name": "project", "required": True, "type": "str"},
-                        {
-                            "name": "language",
-                            "required": True,
-                            "type": "list",
-                            "items": [{"required": True, "type": "str"}],
-                        },
-                    ],
-                },
-            ],
-        ],
-    )
-    def test_compare_with_other_has_different_element(self, items_data: List[dict]):
-        resp_prop = ResponseProperty(
-            name="data",
-            required=True,
-            value_type="dict",
-            value_format=None,
-            items=[
-                {"name": "id", "required": True, "type": "str"},
-                {"name": "name", "required": True, "type": "str"},
-                {"name": "project", "required": True, "type": "list", "items": [{"required": True, "type": "str"}]},
-                {
-                    "name": "responsibility",
-                    "required": True,
-                    "type": "list",
-                    "items": [
-                        {"name": "project", "required": True, "type": "str"},
-                        {
-                            "name": "language",
-                            "required": True,
-                            "type": "list",
-                            "items": [{"required": True, "type": "str"}],
-                        },
-                    ],
-                },
-            ],
-        )
-        diff_resp_prop = ResponseProperty(
-            name=resp_prop.name,
-            required=resp_prop.required,
-            value_type=resp_prop.value_type,
-            value_format=resp_prop.value_format,
-            items=items_data,
-        )
-        assert resp_prop != diff_resp_prop
+    @property
+    def _data_model_not_instantiate_yet(self) -> Type[ResponseProperty]:
+        return ResponseProperty
+
+    @property
+    def _data_model_constructor(self) -> dict:
+        return {
+            "name": "data",
+            "required": True,
+            "value_type": "dict",
+            "value_format": None,
+        }
 
 
 class TestHTTPResponse(TemplatableConfigTestSuite, CheckableTestSuite):

--- a/test/unit_test/model/api_config/item.py
+++ b/test/unit_test/model/api_config/item.py
@@ -6,7 +6,10 @@ import pytest
 from pymock_api.model.api_config import IteratorItem
 from pymock_api.model.api_config._base import _HasItemsPropConfig
 
-from ...._values import _Test_Response_Property_Details_Dict
+from ...._values import (
+    _Test_Iterable_Parameter_Items,
+    _Test_Response_Property_Details_Dict,
+)
 from ._base import CheckableTestSuite, _assertion_msg, set_checking_test_data
 
 
@@ -71,3 +74,12 @@ class TestIteratorItem(CheckableTestSuite):
             str(exc_info.value),
             re.IGNORECASE,
         )
+
+    def test_compare_with_other_has_different_element(self, sut: IteratorItem):
+        copy_sut = IteratorItem(
+            name=sut.name,
+            required=sut.required,
+            value_type=sut.value_type,
+            items=_Test_Iterable_Parameter_Items,
+        )
+        assert sut != copy_sut

--- a/test/unit_test/model/api_config/item.py
+++ b/test/unit_test/model/api_config/item.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, List
+from typing import Any, Type
 
 import pytest
 
@@ -7,10 +7,15 @@ from pymock_api.model.api_config import IteratorItem
 from pymock_api.model.api_config._base import _HasItemsPropConfig
 
 from ...._values import _Test_Response_Property_Details_Dict
-from ._base import CheckableTestSuite, _assertion_msg, set_checking_test_data
+from ._base import (
+    CheckableTestSuite,
+    HasItemsPropConfigTestSuite,
+    _assertion_msg,
+    set_checking_test_data,
+)
 
 
-class TestIteratorItem(CheckableTestSuite):
+class TestIteratorItem(CheckableTestSuite, HasItemsPropConfigTestSuite):
     test_data_dir = "item"
     set_checking_test_data(test_data_dir)
 
@@ -72,91 +77,14 @@ class TestIteratorItem(CheckableTestSuite):
             re.IGNORECASE,
         )
 
-    @pytest.mark.parametrize(
-        "items_data",
-        [
-            # Miss columns
-            [
-                {"name": "id", "required": True, "type": "str"},
-                {"name": "name", "required": True, "type": "str"},
-            ],
-            # Have columns it doesn't have
-            [
-                {"name": "id", "required": True, "type": "str"},
-                {"name": "name", "required": True, "type": "str"},
-                {"name": "what_is_this", "required": True, "type": "str"},
-            ],
-            # Details in property *items* are different
-            [
-                {"name": "id", "required": True, "type": "str"},
-                {"name": "name", "required": True, "type": "str"},
-                {"name": "project", "required": False, "type": "list", "items": [{"required": True, "type": "str"}]},
-                {
-                    "name": "responsibility",
-                    "required": True,
-                    "type": "list",
-                    "items": [
-                        {"name": "project", "required": True, "type": "str"},
-                        {
-                            "name": "language",
-                            "required": True,
-                            "type": "list",
-                            "items": [{"required": True, "type": "str"}],
-                        },
-                    ],
-                },
-            ],
-            # Details in property *items.items* are different
-            [
-                {"name": "id", "required": True, "type": "str"},
-                {"name": "name", "required": True, "type": "str"},
-                {"name": "project", "required": True, "type": "list", "items": [{"required": True, "type": "int"}]},
-                {
-                    "name": "responsibility",
-                    "required": True,
-                    "type": "list",
-                    "items": [
-                        {"name": "project", "required": True, "type": "str"},
-                        {
-                            "name": "language",
-                            "required": True,
-                            "type": "list",
-                            "items": [{"required": True, "type": "str"}],
-                        },
-                    ],
-                },
-            ],
-        ],
-    )
-    def test_compare_with_other_has_different_element(self, items_data: List[dict]):
-        item = IteratorItem(
-            name="data",
-            required=True,
-            value_type="dict",
-            items=[
-                {"name": "id", "required": True, "type": "str"},
-                {"name": "name", "required": True, "type": "str"},
-                {"name": "project", "required": True, "type": "list", "items": [{"required": True, "type": "str"}]},
-                {
-                    "name": "responsibility",
-                    "required": True,
-                    "type": "list",
-                    "items": [
-                        {"name": "project", "required": True, "type": "str"},
-                        {
-                            "name": "language",
-                            "required": True,
-                            "type": "list",
-                            "items": [{"required": True, "type": "str"}],
-                        },
-                    ],
-                },
-            ],
-        )
-        diff_item = IteratorItem(
-            name=item.name,
-            required=item.required,
-            value_type=item.value_type,
-            items=items_data,
-        )
-        assert item != diff_item
+    @property
+    def _data_model_not_instantiate_yet(self) -> Type[IteratorItem]:
+        return IteratorItem
+
+    @property
+    def _data_model_constructor(self) -> dict:
+        return {
+            "name": "data",
+            "required": True,
+            "value_type": "dict",
+        }

--- a/test/unit_test/model/api_config/item.py
+++ b/test/unit_test/model/api_config/item.py
@@ -1,15 +1,12 @@
 import re
-from typing import Any
+from typing import Any, List
 
 import pytest
 
 from pymock_api.model.api_config import IteratorItem
 from pymock_api.model.api_config._base import _HasItemsPropConfig
 
-from ...._values import (
-    _Test_Iterable_Parameter_Items,
-    _Test_Response_Property_Details_Dict,
-)
+from ...._values import _Test_Response_Property_Details_Dict
 from ._base import CheckableTestSuite, _assertion_msg, set_checking_test_data
 
 
@@ -75,11 +72,91 @@ class TestIteratorItem(CheckableTestSuite):
             re.IGNORECASE,
         )
 
-    def test_compare_with_other_has_different_element(self, sut: IteratorItem):
-        copy_sut = IteratorItem(
-            name=sut.name,
-            required=sut.required,
-            value_type=sut.value_type,
-            items=_Test_Iterable_Parameter_Items,
+    @pytest.mark.parametrize(
+        "items_data",
+        [
+            # Miss columns
+            [
+                {"name": "id", "required": True, "type": "str"},
+                {"name": "name", "required": True, "type": "str"},
+            ],
+            # Have columns it doesn't have
+            [
+                {"name": "id", "required": True, "type": "str"},
+                {"name": "name", "required": True, "type": "str"},
+                {"name": "what_is_this", "required": True, "type": "str"},
+            ],
+            # Details in property *items* are different
+            [
+                {"name": "id", "required": True, "type": "str"},
+                {"name": "name", "required": True, "type": "str"},
+                {"name": "project", "required": False, "type": "list", "items": [{"required": True, "type": "str"}]},
+                {
+                    "name": "responsibility",
+                    "required": True,
+                    "type": "list",
+                    "items": [
+                        {"name": "project", "required": True, "type": "str"},
+                        {
+                            "name": "language",
+                            "required": True,
+                            "type": "list",
+                            "items": [{"required": True, "type": "str"}],
+                        },
+                    ],
+                },
+            ],
+            # Details in property *items.items* are different
+            [
+                {"name": "id", "required": True, "type": "str"},
+                {"name": "name", "required": True, "type": "str"},
+                {"name": "project", "required": True, "type": "list", "items": [{"required": True, "type": "int"}]},
+                {
+                    "name": "responsibility",
+                    "required": True,
+                    "type": "list",
+                    "items": [
+                        {"name": "project", "required": True, "type": "str"},
+                        {
+                            "name": "language",
+                            "required": True,
+                            "type": "list",
+                            "items": [{"required": True, "type": "str"}],
+                        },
+                    ],
+                },
+            ],
+        ],
+    )
+    def test_compare_with_other_has_different_element(self, items_data: List[dict]):
+        item = IteratorItem(
+            name="data",
+            required=True,
+            value_type="dict",
+            items=[
+                {"name": "id", "required": True, "type": "str"},
+                {"name": "name", "required": True, "type": "str"},
+                {"name": "project", "required": True, "type": "list", "items": [{"required": True, "type": "str"}]},
+                {
+                    "name": "responsibility",
+                    "required": True,
+                    "type": "list",
+                    "items": [
+                        {"name": "project", "required": True, "type": "str"},
+                        {
+                            "name": "language",
+                            "required": True,
+                            "type": "list",
+                            "items": [{"required": True, "type": "str"}],
+                        },
+                    ],
+                },
+            ],
         )
-        assert sut != copy_sut
+        diff_item = IteratorItem(
+            name=item.name,
+            required=item.required,
+            value_type=item.value_type,
+            items=items_data,
+        )
+        assert item != diff_item

--- a/test/unit_test/model/enums.py
+++ b/test/unit_test/model/enums.py
@@ -300,6 +300,33 @@ class TestResponseStrategy(EnumTestSuite):
                 },
             ),
             (
+                ResponseStrategy.STRING,
+                {
+                    "$ref": "#/components/schemas/NestedFooResponse",
+                },
+                {
+                    "id": "random integer value",
+                    "name": "random string value",
+                    "data": [
+                        {
+                            "id": "random integer value",
+                            "value": "random string value",
+                            "url": "random string value",
+                            "urlProperties": {
+                                "homePage": {
+                                    "domain": "random string value",
+                                    "needAuth": "random boolean value",
+                                },
+                                "detailInfo": {
+                                    "domain": "random string value",
+                                    "needAuth": "random boolean value",
+                                },
+                            },
+                        },
+                    ],
+                },
+            ),
+            (
                 ResponseStrategy.OBJECT,
                 {
                     "type": "object",
@@ -351,13 +378,62 @@ class TestResponseStrategy(EnumTestSuite):
                     },
                 ],
             ),
+            (
+                ResponseStrategy.OBJECT,
+                {
+                    "$ref": "#/components/schemas/NestedFooResponse",
+                },
+                [
+                    {"name": "id", "required": True, "type": "int", "format": None, "items": None},
+                    {"name": "name", "required": False, "type": "str", "format": None, "items": None},
+                    {
+                        "name": "data",
+                        "required": False,
+                        "format": None,
+                        "type": "list",
+                        "items": [
+                            {"name": "id", "required": True, "type": "int"},
+                            {"name": "value", "required": True, "type": "str"},
+                            {"name": "url", "required": True, "type": "str"},
+                            {
+                                "name": "urlProperties",
+                                "required": False,
+                                "format": None,
+                                "type": "dict",
+                                "items": [
+                                    {
+                                        "name": "homePage",
+                                        "required": True,
+                                        "type": "dict",
+                                        "format": None,
+                                        "items": [
+                                            {"name": "domain", "required": True, "type": "str"},
+                                            {"name": "needAuth", "required": True, "type": "bool"},
+                                        ],
+                                    },
+                                    {
+                                        "name": "detailInfo",
+                                        "required": True,
+                                        "type": "dict",
+                                        "format": None,
+                                        "items": [
+                                            {"name": "domain", "required": True, "type": "str"},
+                                            {"name": "needAuth", "required": True, "type": "bool"},
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            ),
         ],
     )
     def test_generate_response_from_data(
         self, ut_enum: ResponseStrategy, test_response_data: dict, expected_value: str
     ):
         # Pre-process
-        if test_response_data["type"] == "array":
+        if test_response_data.get("type", "array") == "array":
             set_component_definition(
                 OpenAPIV3SchemaParser(
                     data={


### PR DESCRIPTION
### _Target_

* Support nested data with ``dict`` type in configuration
* GitHub project ticket: https://github.com/users/Chisanan232/projects/2/views/1?pane=issue&itemId=60712969


### _Effecting Scope_

* Nothing for breaking changes. But let the test fail could be more clear.


### _Description_

* Support nested data with ``dict`` type object.
    * Support parse the schema key ``additionalProperties `` in OpenAPI document config.
* Add more test data for testing nested data with ``dict`` type object.
* Fix the issue about setting template configuration with incorrect data model.
    * For example, it may set the HTTP response which belong to mock API `B` to mock API `A`.
* Improve the compare logic to let error message in fail test could be more clear and simple.
    * AS-IS:
        <img width="1084" alt="Screenshot 2024-05-14 at 10 34 17 AM" src="https://github.com/Chisanan232/PyMock-API/assets/42397554/09bf6e81-9d93-4dd5-880a-dec8edeada87">
    * TO-BE:
        <img width="614" alt="Screenshot 2024-05-14 at 10 18 00 AM" src="https://github.com/Chisanan232/PyMock-API/assets/42397554/c36fe4a8-ca4c-4007-8d20-dfad21c1e5a6">

