### PR TITLE
🛠🐛💣 [Bug Fix] It cannot parse the API which has variables in URL path finely as Python code.

### DIFF
--- a/pymock_api/server/application/code_generator.py
+++ b/pymock_api/server/application/code_generator.py
@@ -193,14 +193,6 @@ class FastAPICodeGenerator(BaseWebServerCodeGenerator):
             + define_function_for_api
         )
 
-    def _parse_variable_in_api(self, api_function_name: str) -> Dict[str, str]:
-        has_variable_in_url = re.findall(r"<\w{1,32}>", api_function_name)
-        var_mapping_table = {}
-        for one_var_in_url in has_variable_in_url:
-            new_one_var_in_url = str(one_var_in_url).replace("<", "var_").replace(">", "")
-            var_mapping_table[one_var_in_url] = new_one_var_in_url
-        return var_mapping_table
-
     def _define_api_function_pycode(self, api_name: str, api_config: MockAPI) -> str:  # type: ignore[override]
         # The code implementation is different if the HTTP method is *GET* or not
         if api_config.http.request.method.upper() != "GET":  # type: ignore[union-attr]

--- a/pymock_api/server/application/code_generator.py
+++ b/pymock_api/server/application/code_generator.py
@@ -349,4 +349,7 @@ class FastAPICodeGenerator(BaseWebServerCodeGenerator):
         return new_url
 
     def _api_controller_name(self, api_name: str) -> str:
-        return api_name.replace("-", "_")
+        api_function_name = api_name.replace("-", "_")
+        for var_in_url, new_name in self._variables_in_url.items():
+            api_function_name = api_function_name.replace(var_in_url, new_name)
+        return api_function_name

--- a/pymock_api/server/application/code_generator.py
+++ b/pymock_api/server/application/code_generator.py
@@ -265,7 +265,7 @@ class FastAPICodeGenerator(BaseWebServerCodeGenerator):
 
     def _api_name_as_camel_case(self, api_name: str) -> str:
         new_api_name: List[str] = []
-        for i in map(lambda e: e.split("-") if "-" in e else e, api_name.split("_")):
+        for i in map(lambda e: e.split("-") if "-" in e else e, self._api_controller_name(api_name).split("_")):
             if type(i) is list:
                 new_api_name.extend(i)
             else:

--- a/pymock_api/server/application/code_generator.py
+++ b/pymock_api/server/application/code_generator.py
@@ -31,10 +31,26 @@ class BaseWebServerCodeGenerator(metaclass=ABCMeta):
         """
 
     def _parse_variable_in_api(self, api_function_name: str) -> Dict[str, str]:
-        has_variable_in_url = re.findall(r"<\w{1,32}>", api_function_name)
+        var_mapping_table_with_angle_brackets = self._parse_variable_in_api_with_prefix(
+            api_function_name=api_function_name, first_prefix="<", last_prefix=">"
+        )
+        var_mapping_table_with_curly_brackets = self._parse_variable_in_api_with_prefix(
+            api_function_name=api_function_name, first_prefix="{", last_prefix="}"
+        )
+        var_mapping_table_with_angle_brackets.update(var_mapping_table_with_curly_brackets)
+        return var_mapping_table_with_angle_brackets
+
+    def _parse_variable_in_api_with_prefix(
+        self, api_function_name: str, first_prefix: str, last_prefix: str
+    ) -> Dict[str, str]:
+        has_variable_in_url = re.findall(
+            re.escape(first_prefix) + r"[\w\-_]{1,32}" + re.escape(last_prefix), api_function_name
+        )
         var_mapping_table = {}
         for one_var_in_url in has_variable_in_url:
-            new_one_var_in_url = str(one_var_in_url).replace("<", "var_").replace(">", "")
+            new_one_var_in_url = (
+                str(one_var_in_url).replace(first_prefix, "var_").replace(last_prefix, "").replace("-", "_")
+            )
             var_mapping_table[one_var_in_url] = new_one_var_in_url
         return var_mapping_table
 

--- a/test/unit_test/server/application/code_generator.py
+++ b/test/unit_test/server/application/code_generator.py
@@ -84,26 +84,7 @@ class WebServerCodeGeneratorTestSpec(metaclass=ABCMeta):
     @pytest.mark.parametrize(
         ("api_name", "expect_var_mapping_table"),
         [
-            # For *FlaskCodeGenerator*
-            ("/foo/api/url", {}),
-            ("/foo-boo/api/url", {}),
-            ("/foo/api/url/<id>", {"<id>": "var_id"}),
-            ("/foo-boo/api/url/<id>", {"<id>": "var_id"}),
-            ("/foo/api/url/<id>/test/<other-id>", {"<id>": "var_id", "<other-id>": "var_other_id"}),
-            ("/foo/api/url/<id>/<other-id>", {"<id>": "var_id", "<other-id>": "var_other_id"}),
-            ("/foo-boo/api/url/<id>", {"<id>": "var_id"}),
-            ("/foo-boo/api/url/<id>/test/<other-id>", {"<id>": "var_id", "<other-id>": "var_other_id"}),
-            ("/foo-boo/api/url/<id>/<other-id>", {"<id>": "var_id", "<other-id>": "var_other_id"}),
-            # For *FastAPICodeGenerator*
-            ("foo_api_url", {}),
-            ("foo-boo_api_url", {}),
-            ("foo_api_url_{id}", {"{id}": "var_id"}),
-            ("foo-boo_api_url_{id}", {"{id}": "var_id"}),
-            ("foo_api_url_{id}_test_{other-id}", {"{id}": "var_id", "{other-id}": "var_other_id"}),
-            ("foo_api_url_{id}_{other-id}", {"{id}": "var_id", "{other-id}": "var_other_id"}),
-            ("foo-boo_api_url_{id}", {"{id}": "var_id"}),
-            ("foo-boo_api_url_{id}_test_{other-id}", {"{id}": "var_id", "{other-id}": "var_other_id"}),
-            ("foo-boo_api_url_{id}_{other-id}", {"{id}": "var_id", "{other-id}": "var_other_id"}),
+            # NOTE: It should implement the test data here in child-class
         ],
     )
     def test__parse_variable_in_api(
@@ -155,6 +136,27 @@ class TestFlaskCodeGenerator(WebServerCodeGeneratorTestSpec):
         with patch.object(sut, "_record_api_params_info"):
             with pytest.raises(TypeError):
                 sut.add_api(api_name=ut_url, api_config=ut_api_config)
+
+    @pytest.mark.parametrize(
+        ("api_name", "expect_var_mapping_table"),
+        [
+            ("/foo/api/url", {}),
+            ("/foo-boo/api/url", {}),
+            ("/foo/api/url/<id>", {"<id>": "var_id"}),
+            ("/foo-boo/api/url/<id>", {"<id>": "var_id"}),
+            ("/foo/api/url/<id>/test/<other-id>", {"<id>": "var_id", "<other-id>": "var_other_id"}),
+            ("/foo/api/url/<id>/<other-id>", {"<id>": "var_id", "<other-id>": "var_other_id"}),
+            ("/foo-boo/api/url/<id>", {"<id>": "var_id"}),
+            ("/foo-boo/api/url/<id>/test/<other-id>", {"<id>": "var_id", "<other-id>": "var_other_id"}),
+            ("/foo-boo/api/url/<id>/<other-id>", {"<id>": "var_id", "<other-id>": "var_other_id"}),
+        ],
+    )
+    def test__parse_variable_in_api(
+        self, sut: BaseWebServerCodeGenerator, api_name: str, expect_var_mapping_table: Dict[str, str]
+    ):
+        super().test__parse_variable_in_api(
+            sut=sut, api_name=api_name, expect_var_mapping_table=expect_var_mapping_table
+        )
 
 
 FastAPIGenCodeExpect = namedtuple("FastAPIGenCodeExpect", ("func_naming", "req_body_obj_naming"))
@@ -228,3 +230,24 @@ class TestFastAPICodeGenerator(WebServerCodeGeneratorTestSpec):
         with patch.object(sut, "_record_api_params_info"):
             with pytest.raises(TypeError):
                 sut.add_api(api_name=ut_url, api_config=ut_api_config)
+
+    @pytest.mark.parametrize(
+        ("api_name", "expect_var_mapping_table"),
+        [
+            ("foo_api_url", {}),
+            ("foo-boo_api_url", {}),
+            ("foo_api_url_{id}", {"{id}": "var_id"}),
+            ("foo-boo_api_url_{id}", {"{id}": "var_id"}),
+            ("foo_api_url_{id}_test_{other-id}", {"{id}": "var_id", "{other-id}": "var_other_id"}),
+            ("foo_api_url_{id}_{other-id}", {"{id}": "var_id", "{other-id}": "var_other_id"}),
+            ("foo-boo_api_url_{id}", {"{id}": "var_id"}),
+            ("foo-boo_api_url_{id}_test_{other-id}", {"{id}": "var_id", "{other-id}": "var_other_id"}),
+            ("foo-boo_api_url_{id}_{other-id}", {"{id}": "var_id", "{other-id}": "var_other_id"}),
+        ],
+    )
+    def test__parse_variable_in_api(
+        self, sut: BaseWebServerCodeGenerator, api_name: str, expect_var_mapping_table: Dict[str, str]
+    ):
+        super().test__parse_variable_in_api(
+            sut=sut, api_name=api_name, expect_var_mapping_table=expect_var_mapping_table
+        )

--- a/test/unit_test/server/application/code_generator.py
+++ b/test/unit_test/server/application/code_generator.py
@@ -89,6 +89,7 @@ class TestFlaskCodeGenerator(WebServerCodeGeneratorTestSpec):
         ("mock_api_key", "mock_api", "expected_api_func_naming"),
         [
             ("/foo/api/url", MockAPI(url="/foo/api/url", http=Mock(HTTP())), "foo_api_url"),
+            ("/foo-boo/api/url", MockAPI(url="/foo-boo/api/url", http=Mock(HTTP())), "foo_boo_api_url"),
         ],
     )
     def test_generate_pycode_about_annotating_function(
@@ -127,6 +128,7 @@ class TestFastAPICodeGenerator(WebServerCodeGeneratorTestSpec):
         ("mock_api_key", "mock_api", "expected_api_func_naming"),
         [
             ("foo_api_url", MockAPI(url="/foo/api/url", http=Mock(HTTP())), "foo_api_url"),
+            ("foo-boo_api_url", MockAPI(url="/foo-boo/api/url", http=Mock(HTTP())), "foo_boo_api_url"),
         ],
     )
     def test_generate_pycode_about_annotating_function(

--- a/test/unit_test/server/application/code_generator.py
+++ b/test/unit_test/server/application/code_generator.py
@@ -21,16 +21,22 @@ class WebServerCodeGeneratorTestSpec(metaclass=ABCMeta):
     def sut(self) -> BaseWebServerCodeGenerator:
         pass
 
-    def test_generate_pycode_about_annotating_function(self, sut: BaseWebServerCodeGenerator):
-        for_test_api_name = "/Function/name"
-        api = MockAPI(url="/foo/api/url", http=Mock(HTTP()))
-        api.http.request.parameters = [APIParameter().deserialize(p) for p in _Test_API_Parameters]
+    @pytest.mark.parametrize(
+        ("mock_api_key", "mock_api"),
+        [
+            ("/Function/name", MockAPI(url="/foo/api/url", http=Mock(HTTP()))),
+        ],
+    )
+    def test_generate_pycode_about_annotating_function(
+        self, sut: BaseWebServerCodeGenerator, mock_api_key: str, mock_api: MockAPI
+    ):
+        mock_api.http.request.parameters = [APIParameter().deserialize(p) for p in _Test_API_Parameters]
 
         annotate_function_pycode = sut.annotate_function(
-            api_name=for_test_api_name, api_config=self._mock_api_config_data(api)
+            api_name=mock_api_key, api_config=self._mock_api_config_data(mock_api)
         )
 
-        assert sut._api_controller_name(for_test_api_name) in annotate_function_pycode
+        assert sut._api_controller_name(mock_api_key) in annotate_function_pycode
 
     @abstractmethod
     def _mock_api_config_data(self, api: MockAPI) -> Union[MockAPI, List[MockAPI]]:

--- a/test/unit_test/server/application/code_generator.py
+++ b/test/unit_test/server/application/code_generator.py
@@ -92,6 +92,11 @@ class TestFlaskCodeGenerator(WebServerCodeGeneratorTestSpec):
         [
             ("/foo/api/url", MockAPI(url="/foo/api/url", http=Mock(HTTP())), "foo_api_url"),
             ("/foo-boo/api/url", MockAPI(url="/foo-boo/api/url", http=Mock(HTTP())), "foo_boo_api_url"),
+            (
+                "/foo-boo/api/url/<id>",
+                MockAPI(url="/foo-boo/api/url/<id>", http=Mock(HTTP())),
+                "foo_boo_api_url_var_id",
+            ),
         ],
     )
     def test_generate_pycode_about_annotating_function(
@@ -141,6 +146,11 @@ class TestFastAPICodeGenerator(WebServerCodeGeneratorTestSpec):
                 "foo-boo_api_url",
                 MockAPI(url="/foo-boo/api/url", http=Mock(HTTP())),
                 FastAPIGenCodeExpect("foo_boo_api_url", "FooBooApiUrlParameter"),
+            ),
+            (
+                "foo-boo_api_url_{id}",
+                MockAPI(url="/foo-boo/api/url/{id}", http=Mock(HTTP())),
+                FastAPIGenCodeExpect("foo_boo_api_url_var_id", "FooBooApiUrlVarIdParameter"),
             ),
         ],
     )


### PR DESCRIPTION
### _Target_

* It cannot parse the API which has variables in URL path finely as Python code.
* GitHub project task ticket: https://github.com/users/Chisanan232/projects/2/views/1?pane=issue&itemId=64043177


### _Effecting Scope_

* Fix bugs without breaking change.


### _Description_

* Add unit test for the bug.
* Extract common logic into protected function and extract 2 parameters about prefix.
* Modify the regex which could be more correct to parse variables in URL path.
