### PR TITLE
📝📑📗 [Docs] Add info at new property ``is_empty`` at configuration section ``<mock API>.http.response`` in documentation.

### DIFF
--- a/docs/configure-references/mocked-apis/apis/http/response.md
+++ b/docs/configure-references/mocked-apis/apis/http/response.md
@@ -80,6 +80,15 @@ The data format.
     Currently, it just let you set this option. But it doesn't have essentially function to work.
 
 
+#### ``properties[*].is_empty``
+
+If the data type (property ``properties[*].type``) is collection and is empty body, this option will be true. In the 
+other words, it would be valid about ``properties[*].items`` is empty when ``properties[*].type`` is collection with 
+this option is true.
+
+In generally, this option would be used for sub-command line ``pull``.
+
+
 #### ``properties[*].items``
 
 If the data type of value is list type, it should use this key to configure its element details. The element detail follow 


### PR DESCRIPTION
### _Target_

* Add info at new property ``is_empty`` at configuration section ``<mock API>.http.response`` in documentation.
* Relative PR:
    * [#277 - 🛠🐛💣 [Bug Fix] Fix issue about it cannot finely configure setting at empty body column in response.](https://github.com/Chisanan232/PyMock-API/pull/277)
* GitHub project task ticket: https://github.com/users/Chisanan232/projects/2/views/1?pane=issue&itemId=65464793



### _Effecting Scope_

* Nothing at breaking updates. Just add new info.


### _Description_

* Add detail info about new property ``is_empty`` at configuration section ``<mock API>.http.response``.
