### PR TITLE
📝📑📗 [Docs] Add info about new argument ``--source-file`` in sub-command line **pull** in document.

### DIFF
--- a/docs/command-line-usage/subcmd-pull.md
+++ b/docs/command-line-usage/subcmd-pull.md
@@ -20,8 +20,8 @@ quickly.
 
 ## ``--source`` or ``-s`` <API document URL\>
 
-Set the source where it should try to get the API documentation configuration and convert it as **_PyMock-API_** format
-configuration.
+Set the source that is the endpoint of OpenAPI document it would try to get the API documentation configuration and 
+convert it as **_PyMock-API_** format configuration.
 
 It receives a string value about the host address or URL path.
 

--- a/docs/command-line-usage/subcmd-pull.md
+++ b/docs/command-line-usage/subcmd-pull.md
@@ -26,6 +26,14 @@ configuration.
 It receives a string value about the host address or URL path.
 
 
+## ``--source-file`` or ``-f`` <API document configuration file\>
+
+Set the source file that is the specific file it would try to get the API documentation configuration and convert it 
+as **_PyMock-API_** format configuration.
+
+It receives a string value about the configuration file path.
+
+
 ## ``--base-url`` <base API path\>
 
 Set the base URL for deserialization of API documentation configuration.


### PR DESCRIPTION
### _Target_

* Add info about new argument ``--source-file`` in sub-command line **pull** in document.
* Relative PR:
    * [#279 - 🎉🎊🍾 [New Feature] Add one new command line argument --source-file for getting OpenAPI document details by configuration file.](https://github.com/Chisanan232/PyMock-API/pull/279)
* GitHub project task ticket: https://github.com/users/Chisanan232/projects/2/views/1?pane=issue&itemId=65657483


### _Effecting Scope_

* No any breaking changes.


### _Description_

* Add info about new argument ``--source-file`` in sub-command line **pull**.
* Update the info at argument ``--source`` to be more clear and readable.
