### PR TITLE
🤖⚙️🔧 [Improvement] Upgrade the reusable GitHub Action workflow from `6` to `6.1`.

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   build_git-tag_and_create_github-release:
 #    name: Build git tag and GitHub release if it needs
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_build_git-tag_and_create_github-release.yaml@v6
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_build_git-tag_and_create_github-release.yaml@v6.1
     secrets:
       github_auth_token: ${{ secrets.GITHUB_TOKEN }}
     with:
@@ -24,7 +24,7 @@ jobs:
   push_python_pkg_to_pypi:
 #    name: Check about it could work finely by installing the Python package with setup.py file
     needs: build_git-tag_and_create_github-release
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_push_pypi.yaml@v6
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_push_pypi.yaml@v6.1
     with:
       build-type: poetry
       release-type: ${{ needs.build_git-tag_and_create_github-release.outputs.python_release_version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
 #    name: Organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: build-and-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_upload_test_cov_report.yaml@v6
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_upload_test_cov_report.yaml@v6.1
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -89,7 +89,7 @@ jobs:
 #    name: Organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: build-and-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_upload_test_cov_report.yaml@v6
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_upload_test_cov_report.yaml@v6.1
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -103,7 +103,7 @@ jobs:
 #    name: Organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: build-and-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_upload_test_cov_report.yaml@v6
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_upload_test_cov_report.yaml@v6.1
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -117,7 +117,7 @@ jobs:
 #    name: Organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: build-and-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_upload_test_cov_report.yaml@v6
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_upload_test_cov_report.yaml@v6.1
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -131,7 +131,7 @@ jobs:
 #    name: SonarCloud Scan
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: build-and-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_sonarqube_scan.yaml@v6
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_sonarqube_scan.yaml@v6.1
     secrets:
       sonar_token: ${{ secrets.SONAR_TOKEN }}
     with:
@@ -142,7 +142,7 @@ jobs:
 #    name: Check about it could work finely by installing the Python package with setup.py file
     needs: [unit-test_codecov_finish, integration-test_codecov_finish, system-test_codecov_finish, all-test_codecov_finish, sonarcloud_finish]
     if: ${{ github.ref_name == 'release' || github.ref_name == 'master' }}
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_pre-building_test.yaml@v6
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_pre-building_test.yaml@v6.1
     with:
       build-type: poetry
       python_package_name: pymock-api

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   check_version_info:
 #    name: Check the package version info to make sure whether it should release Docker image or not.
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_build_git-tag_and_create_github-release.yaml@v6
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_build_git-tag_and_create_github-release.yaml@v6.1
     secrets:
       github_auth_token: ${{ secrets.GITHUB_TOKEN }}
     with:

--- a/.github/workflows/rw_build_and_test.yaml
+++ b/.github/workflows/rw_build_and_test.yaml
@@ -6,21 +6,21 @@ on:
 jobs:
   prep_unit-test:
 #    name: Prepare all unit test items
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_get_tests.yaml@v6
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_get_tests.yaml@v6.1
     with:
       shell_arg: test/unit_test/
 
 
   prep_integration-test:
 #    name: Prepare all integration test items
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_get_tests.yaml@v6
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_get_tests.yaml@v6.1
     with:
       shell_arg: test/integration_test/
 
 
   prep_system-test:
 #    name: Prepare all system test items
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_get_tests.yaml@v6
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_get_tests.yaml@v6.1
     with:
       shell_arg: test/system_test/
 
@@ -28,7 +28,7 @@ jobs:
   run_unit-test:
 #    name: Run all unit test items
     needs: prep_unit-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_poetry_run_test_with_multi_py_versions.yaml@v6
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_poetry_run_test_with_multi_py_versions.yaml@v6.1
     with:
       test_type: unit-test
       all_test_items_paths: ${{needs.prep_unit-test.outputs.all_test_items}}
@@ -37,7 +37,7 @@ jobs:
   run_integration-test:
 #    name: Run all integration test items
     needs: prep_integration-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_poetry_run_test_with_multi_py_versions.yaml@v6
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_poetry_run_test_with_multi_py_versions.yaml@v6.1
     with:
       test_type: integration-test
       all_test_items_paths: ${{needs.prep_integration-test.outputs.all_test_items}}
@@ -46,7 +46,7 @@ jobs:
   run_system-test:
 #    name: Run all system test items
     needs: prep_system-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_poetry_run_test_with_multi_py_versions.yaml@v6
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_poetry_run_test_with_multi_py_versions.yaml@v6.1
     with:
       test_type: system-test
       all_test_items_paths: ${{needs.prep_system-test.outputs.all_test_items}}
@@ -56,7 +56,7 @@ jobs:
 #    name: For unit test, organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: run_unit-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v6
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v6.1
     with:
       test_type: unit-test
 
@@ -65,7 +65,7 @@ jobs:
 #    name: For unit test, organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: run_integration-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v6
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v6.1
     with:
       test_type: integration-test
 
@@ -74,7 +74,7 @@ jobs:
 #    name: For unit test, organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: run_system-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v6
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v6.1
     with:
       test_type: system-test
 
@@ -83,6 +83,6 @@ jobs:
 #    name: Organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: [run_unit-test, run_integration-test, run_system-test]
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v6
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v6.1
     with:
       test_type: all-test


### PR DESCRIPTION
### _Target_

* Upgrade the reusable GitHub Action workflow from `6` to `6.1`.
    * Fix the broken CI process about it cannot upload the test coverage reports because they all are hidden files.


### _Effecting Scope_

* All the CI processes in this project.


### _Description_

* Upgrade all the usages of CI processes in this project.
