### PR TITLE
🛠🐛💣 [Bug Fix] Fix the bug in common values of test.

### DIFF
--- a/test/_values.py
+++ b/test/_values.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from typing import Dict, List, Union
+from typing import Dict, List, Tuple, Union
 from unittest.mock import Mock
 
 from pymock_api.model.enums import ResponseStrategy
@@ -487,7 +487,7 @@ _Dummy_Add_Arg_Parameter: List[dict] = [{"name": "arg1", "required": True, "type
 
 
 # Test subcommand *add* options
-def _generate_response_for_add(strategy: ResponseStrategy) -> tuple[ResponseStrategy, List[Union[str, dict]]]:
+def _generate_response_for_add(strategy: ResponseStrategy) -> Tuple[ResponseStrategy, List[Union[str, dict]]]:
     _strategy: ResponseStrategy = strategy
     if strategy is ResponseStrategy.STRING:
         _values: List[str] = ["This is foo."]


### PR DESCRIPTION
### _Target_

* Fix the bug in common values of test.
    * In Python 3.8 version, object ``type`` cannot be subscriptable.


### _Effecting Scope_

* The test running part which would cause CI be broken.


### _Description_

* Modify to use ``typing.Tuple`` to replace type object ``tuple`` to fix broken test if Python version is ``3.8``.
