### PR TITLE
🛠🐛💣 [Bug Fix] Fix all broken tests in CI process.

### DIFF
--- a/pymock_api/model/api_config/format.py
+++ b/pymock_api/model/api_config/format.py
@@ -287,6 +287,10 @@ class Format(_Config, _Checkable):
             return f"oen of the enums value *{self.enums}*"
         elif self.strategy is FormatStrategy.CUSTOMIZE:
             return f"like format as *{self.customize}*. Please refer to the property *variables* to know the details of variable settings."
+        elif self.strategy is FormatStrategy.FROM_TEMPLATE:
+            temp_format: Optional[Format] = self._current_template.common_config.format.get_format(self.use_name)
+            assert temp_format is not None
+            return temp_format.expect_format_log_msg(data_type=data_type)
         else:
             raise ValueError("Unsupported FormatStrategy")
 

--- a/pymock_api/model/http.py
+++ b/pymock_api/model/http.py
@@ -1,0 +1,31 @@
+from enum import Enum
+from typing import Union
+
+
+class HTTPMethod(Enum):
+    """HTTP methods
+
+    Methods from the following RFCs are all observed:
+
+        * RFC 7231: Hypertext Transfer Protocol (HTTP/1.1), obsoletes 2616
+        * RFC 5789: PATCH Method for HTTP
+    """
+
+    def __contains__(cls, member: Union[str, "Enum"]) -> bool:
+        if not isinstance(member, (str, Enum)):
+            raise TypeError(
+                "unsupported operand type(s) for 'in': '%s' and '%s'"
+                % (type(member).__qualname__, cls.__class__.__qualname__)
+            )
+        member_value = member if isinstance(member, str) else member.value
+        return member_value.upper() in [m.value.upper() for m in HTTPMethod]
+
+    CONNECT = "CONNECT"
+    DELETE = "DELETE"
+    GET = "GET"
+    HEAD = "HEAD"
+    OPTIONS = "OPTIONS"
+    PATCH = "PATCH"
+    POST = "POST"
+    PUT = "PUT"
+    TRACE = "TRACE"

--- a/pymock_api/model/http.py
+++ b/pymock_api/model/http.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import Union
 
 
 class HTTPMethod(Enum):
@@ -10,15 +9,6 @@ class HTTPMethod(Enum):
         * RFC 7231: Hypertext Transfer Protocol (HTTP/1.1), obsoletes 2616
         * RFC 5789: PATCH Method for HTTP
     """
-
-    def __contains__(cls, member: Union[str, "Enum"]) -> bool:
-        if not isinstance(member, (str, Enum)):
-            raise TypeError(
-                "unsupported operand type(s) for 'in': '%s' and '%s'"
-                % (type(member).__qualname__, cls.__class__.__qualname__)
-            )
-        member_value = member if isinstance(member, str) else member.value
-        return member_value.upper() in [m.value.upper() for m in HTTPMethod]
 
     CONNECT = "CONNECT"
     DELETE = "DELETE"

--- a/pymock_api/model/openapi/base_config.py
+++ b/pymock_api/model/openapi/base_config.py
@@ -508,7 +508,7 @@ class BaseReferenceConfigProperty(BaseReferencialConfig):
 class BaseReferenceConfig(BaseAPIDocConfig):
     title: Optional[str] = None
     value_type: str = field(default_factory=str)  # unused
-    required: Optional[list[str]] = None
+    required: Optional[List[str]] = None
     properties: Dict[str, BaseReferenceConfigProperty] = field(default_factory=dict)
 
     @classmethod

--- a/pymock_api/model/openapi/base_config.py
+++ b/pymock_api/model/openapi/base_config.py
@@ -3,9 +3,14 @@ import re
 from abc import ABC, ABCMeta, abstractmethod
 from collections import namedtuple
 from dataclasses import dataclass, field
-from http import HTTPMethod, HTTPStatus
 from pydoc import locate
 from typing import Any, Callable, Dict, List, Optional, Type, Union
+
+try:
+    from http import HTTPMethod, HTTPStatus
+except ImportError:
+    from http import HTTPStatus
+    from pymock_api.model.http import HTTPMethod  # type: ignore[assignment]
 
 from ._base_model_adapter import (
     BaseAPIAdapter,

--- a/pymock_api/model/openapi/config.py
+++ b/pymock_api/model/openapi/config.py
@@ -228,7 +228,7 @@ class ReferenceConfigProperty(BaseReferenceConfigProperty):
 class ReferenceConfig(BaseReferenceConfig):
     title: Optional[str] = None
     value_type: str = field(default_factory=str)  # unused
-    required: Optional[list[str]] = None
+    required: Optional[List[str]] = None
     properties: Dict[str, BaseReferenceConfigProperty] = field(default_factory=dict)
 
     _adapter_factory = AdapterFactory()

--- a/pymock_api/model/openapi/config.py
+++ b/pymock_api/model/openapi/config.py
@@ -1,7 +1,12 @@
 from abc import abstractmethod
 from dataclasses import dataclass, field
-from http import HTTPMethod, HTTPStatus
 from typing import Any, Dict, List, Optional, Type, Union, cast
+
+try:
+    from http import HTTPMethod, HTTPStatus
+except ImportError:
+    from http import HTTPStatus
+    from pymock_api.model.http import HTTPMethod  # type: ignore[assignment]
 
 from ...exceptions import CannotParsingAPIDocumentVersion
 from ..api_config import APIConfig as PyMockAPI_APIConfig
@@ -484,7 +489,6 @@ class APIConfig(BaseAPIConfig):
             initial_api_config = APIConfigWithMethodV3()
 
         for http_method, config in data.items():
-            assert http_method.upper() in HTTPMethod
             self.api[HTTPMethod(http_method.upper())] = initial_api_config.deserialize(config)
 
         return self

--- a/test/unit_test/model/api_config/apis/inner_format.py
+++ b/test/unit_test/model/api_config/apis/inner_format.py
@@ -1174,7 +1174,19 @@ class TestFormatWithCustomizeStrategy(TestFormatWithGeneralStrategy, CheckableTe
 
     @pytest.mark.parametrize("strategy", [s for s in FormatStrategy])
     def test_valid_expect_format_log_msg(self, strategy: FormatStrategy):
-        non_strategy_format = Format(strategy=strategy)
+        non_strategy_format = Format(strategy=strategy, use_name="test_err_msg")
+        non_strategy_format._current_template = TemplateConfig(
+            common_config=TemplateCommonConfig(
+                format=TemplateFormatConfig(
+                    entities=[
+                        TemplateFormatEntity(
+                            name="test_err_msg",
+                            config=Format(strategy=FormatStrategy.BY_DATA_TYPE),
+                        ),
+                    ]
+                )
+            )
+        )
         msg = non_strategy_format.expect_format_log_msg(data_type="any data type")
         assert msg and isinstance(msg, str)
 

--- a/test/unit_test/model/openapi/config.py
+++ b/test/unit_test/model/openapi/config.py
@@ -11,7 +11,7 @@ except ImportError:
     from http import HTTPStatus
     from pymock_api.model.http import HTTPMethod
 
-from pymock_api import APIConfig
+from pymock_api import APIConfig as PyMockAPI_APIConfig
 from pymock_api.exceptions import CannotParsingAPIDocumentVersion
 from pymock_api.model import MockAPI, OpenAPIVersion
 from pymock_api.model.api_config import _Config
@@ -1275,7 +1275,7 @@ class TestSwaggerAPIDocumentConfig(_OpenAPIDocumentDataModelTestSuite):
 
         data_model.paths = {"/test/v1/foo-home": apis}
 
-    def _verify_api_config_model(self, under_test: APIConfig, data_from: OpenAPIDocumentConfig) -> None:
+    def _verify_api_config_model(self, under_test: PyMockAPI_APIConfig, data_from: OpenAPIDocumentConfig) -> None:
         assert len(under_test.apis.apis.keys()) == len(data_from.paths)
         for api_path, api_details in under_test.apis.apis.items():
             print(f"[DEBUG in test] api_path: {api_path}")
@@ -1411,7 +1411,7 @@ class TestOpenAPIDocumentConfig(_OpenAPIDocumentDataModelTestSuite):
 
         data_model.paths = {"/test/v1/foo-home": apis}
 
-    def _verify_api_config_model(self, under_test: APIConfig, data_from: OpenAPIDocumentConfig) -> None:
+    def _verify_api_config_model(self, under_test: PyMockAPI_APIConfig, data_from: OpenAPIDocumentConfig) -> None:
         assert len(under_test.apis.apis.keys()) == len(data_from.paths)
         for api_path, api_details in under_test.apis.apis.items():
             print(f"[DEBUG in test] api_path: {api_path}")

--- a/test/unit_test/model/openapi/config.py
+++ b/test/unit_test/model/openapi/config.py
@@ -1,10 +1,15 @@
 import random
 import re
 from abc import ABC, ABCMeta, abstractmethod
-from http import HTTPMethod, HTTPStatus
-from typing import List, Optional, Union
+from typing import List, Optional, Tuple, Union
 
 import pytest
+
+try:
+    from http import HTTPMethod, HTTPStatus
+except ImportError:
+    from http import HTTPStatus
+    from pymock_api.model.http import HTTPMethod
 
 from pymock_api import APIConfig
 from pymock_api.exceptions import CannotParsingAPIDocumentVersion
@@ -1279,7 +1284,7 @@ class TestSwaggerAPIDocumentConfig(_OpenAPIDocumentDataModelTestSuite):
             def _find_path(_http_method: HTTPMethod) -> bool:
                 return api_path == f'{_http_method.name.lower()}{path.replace("/", "_")}'
 
-            expect_api_setting = None
+            expect_api_setting: Optional[Tuple[str, HTTPMethod, _BaseAPIConfigWithMethod]] = None
             for path, api_config in data_from.paths.items():
                 expect_apis = list(filter(lambda _http_method: _find_path(_http_method), api_config.api.keys()))
                 if len(expect_apis):
@@ -1293,7 +1298,7 @@ class TestSwaggerAPIDocumentConfig(_OpenAPIDocumentDataModelTestSuite):
             expect_api_config = expect_api_setting[2]
 
             assert api_details.url == expect_path
-            assert api_details.http.request.method == expect_http_method
+            assert api_details.http.request.method == expect_http_method.value
             for api_param in api_details.http.request.parameters:
                 api_param_in_data_from = list(
                     filter(lambda _p: _p.name == api_param.name, expect_api_config.parameters)
@@ -1415,7 +1420,7 @@ class TestOpenAPIDocumentConfig(_OpenAPIDocumentDataModelTestSuite):
             def _find_path(_http_method: HTTPMethod) -> bool:
                 return api_path == f'{_http_method.name.lower()}{path.replace("/", "_")}'
 
-            expect_api_setting = None
+            expect_api_setting: Optional[Tuple[str, HTTPMethod, _BaseAPIConfigWithMethod]] = None
             for path, api_config in data_from.paths.items():
                 expect_apis = list(filter(lambda _http_method: _find_path(_http_method), api_config.api.keys()))
                 if len(expect_apis):
@@ -1429,7 +1434,7 @@ class TestOpenAPIDocumentConfig(_OpenAPIDocumentDataModelTestSuite):
             expect_api_config = expect_api_setting[2]
 
             assert api_details.url == expect_path
-            assert api_details.http.request.method == expect_http_method
+            assert api_details.http.request.method == expect_http_method.value
             for api_param in api_details.http.request.parameters:
                 api_param_in_data_from = list(
                     filter(lambda _p: _p.name == api_param.name, expect_api_config.parameters)


### PR DESCRIPTION
### _Target_

* Fix all broken tests in CI process.


### _Effecting Scope_

* Nothing, just fix broken CI process.


### _Description_

* Fix the syntax issue about object ``type`` is not subscribable under Python 3.10.
* Fix broken test since Python doesn't support ``http.HTTPMethod`` under Python 3.11.
* Fix broken test since missing formatting strategy handling in utility function.
* Fix incorrect data type hint since the duplicate object in imports.
