### PR TITLE
🛠🐛💣 [Bug Fix] Fix the issue about it would generate duplicate request parameter from API documentation configuration.

### DIFF
--- a/pymock_api/log.py
+++ b/pymock_api/log.py
@@ -6,25 +6,25 @@ DEBUG_LEVEL_LOG_DATETIME_FORMAT: str = "%Y-%m-%d %H:%M:%S UTC%z"
 
 
 def init_logger_config(
-    format: str = "",
+    formatter: str = "",
     datefmt: str = "",
     level: int = logging.INFO,
     encoding: str = "utf-8",
 ) -> None:
     if level == logging.DEBUG:
-        format = DEBUG_LEVEL_LOG_FORMAT
+        formatter = DEBUG_LEVEL_LOG_FORMAT
         datefmt = DEBUG_LEVEL_LOG_DATETIME_FORMAT
 
     if sys.version_info >= (3, 9):
         logging.basicConfig(
-            format=format,
+            format=formatter,
             datefmt=datefmt,
             level=level,
             encoding=encoding,
         )
     else:
         logging.basicConfig(
-            format=format,
+            format=formatter,
             datefmt=datefmt,
             level=level,
         )

--- a/test/unit_test/command/check/component.py
+++ b/test/unit_test/command/check/component.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from typing import Union
 from unittest.mock import MagicMock, patch
 
@@ -162,6 +163,31 @@ class TestValidityChecking:
     @pytest.fixture(scope="class")
     def checking(self) -> ValidityChecking:
         return ValidityChecking()
+
+    @pytest.mark.parametrize(
+        ("exit_code", "expect_level"),
+        [
+            # normal exit
+            (0, logging.INFO),
+            # un-normal exit
+            (1, logging.ERROR),
+            (127, logging.ERROR),
+        ],
+    )
+    def test__exit_program(self, checking: ValidityChecking, exit_code: int, expect_level: int):
+        test_msg = "just a message"
+        with patch("logging.info") as info_log:
+            with patch("logging.error") as error_log:
+                with pytest.raises(SystemExit) as system_exit:
+                    checking._exit_program(msg=test_msg, exit_code=exit_code)
+
+                    assert system_exit.value == exit_code
+                    if expect_level == logging.INFO:
+                        assert info_log.assert_called_once_with(test_msg)
+                        assert error_log.assert_not_called()
+                    else:
+                        assert info_log.assert_not_called()
+                        assert error_log.assert_called_once_with(test_msg)
 
 
 class TestSwaggerDiffChecking:

--- a/test/unit_test/log.py
+++ b/test/unit_test/log.py
@@ -1,0 +1,61 @@
+import logging
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from pymock_api.log import (
+    DEBUG_LEVEL_LOG_DATETIME_FORMAT,
+    DEBUG_LEVEL_LOG_FORMAT,
+    init_logger_config,
+)
+
+
+@pytest.mark.parametrize("level", [logging.INFO, logging.WARN, logging.WARNING, logging.ERROR])
+def test_not_debug_level_log_config(level: int):
+    formatter = "this is customize format"
+    datefmt = "this is customize datetime format"
+
+    with patch("logging.basicConfig") as logging_config:
+        init_logger_config(
+            formatter=formatter,
+            datefmt=datefmt,
+            level=level,
+            encoding="utf-8",
+        )
+
+    if sys.version_info >= (3, 9):
+        logging_config.assert_called_once_with(
+            format=formatter,
+            datefmt=datefmt,
+            level=level,
+            encoding="utf-8",
+        )
+    else:
+        logging_config.assert_called_once_with(
+            format=formatter,
+            datefmt=datefmt,
+            level=level,
+        )
+
+
+def test_debug_level_log_config():
+    with patch("logging.basicConfig") as logging_config:
+        init_logger_config(
+            level=logging.DEBUG,
+            encoding="utf-8",
+        )
+
+    if sys.version_info >= (3, 9):
+        logging_config.assert_called_once_with(
+            format=DEBUG_LEVEL_LOG_FORMAT,
+            datefmt=DEBUG_LEVEL_LOG_DATETIME_FORMAT,
+            level=logging.DEBUG,
+            encoding="utf-8",
+        )
+    else:
+        logging_config.assert_called_once_with(
+            format=DEBUG_LEVEL_LOG_FORMAT,
+            datefmt=DEBUG_LEVEL_LOG_DATETIME_FORMAT,
+            level=logging.DEBUG,
+        )

--- a/test/unit_test/model/api_config/_base.py
+++ b/test/unit_test/model/api_config/_base.py
@@ -326,6 +326,31 @@ class CheckableTestSuite(ConfigTestSpec, ABC):
             is_valid_to_work = data_model.is_work()
             assert is_valid_to_work is criteria
 
+    @pytest.mark.parametrize(
+        ("exit_code", "expect_level"),
+        [
+            # normal exit
+            (0, logging.INFO),
+            # un-normal exit
+            (1, logging.ERROR),
+            (127, logging.ERROR),
+        ],
+    )
+    def test__exit_program(self, sut_with_nothing: _Checkable, exit_code: int, expect_level: int):
+        test_msg = "just a message"
+        with patch("logging.info") as info_log:
+            with patch("logging.error") as error_log:
+                with pytest.raises(SystemExit) as system_exit:
+                    sut_with_nothing._exit_program(msg=test_msg, exit_code=exit_code)
+
+                    assert system_exit.value == exit_code
+                    if expect_level == logging.INFO:
+                        assert info_log.assert_called_once_with(test_msg)
+                        assert error_log.assert_not_called()
+                    else:
+                        assert info_log.assert_not_called()
+                        assert error_log.assert_called_once_with(test_msg)
+
 
 class HasItemsPropConfigTestSuite(ConfigTestSpec, ABC):
 


### PR DESCRIPTION
### _Target_

* Fix the issue about it would generate duplicate request parameter from API documentation configuration.


### _Effecting Scope_

* Fix program bug without any breaking change.


### _Description_

* Add new property ``query_in`` to save the information about where the query conditions are.
* Set the request parameters with the new property ``query_in`` to set the request info correctly.
